### PR TITLE
fix(tabStore): align API with tests to unblock CI

### DIFF
--- a/src/pages/HistoryPage.vue
+++ b/src/pages/HistoryPage.vue
@@ -106,7 +106,7 @@ async function handleRerun(entry: HistoryEntry) {
     return
   }
   const database = entry.database
-  const tab = tabStore.createTab(database, undefined, connectionId)
+  const tab = tabStore.createTab(connectionId, database)
   tabStore.updateTabContent(tab.id, entry.sql)
   const createdTab = tabStore.tabs.find(t => t.id === tab.id)
   if (createdTab)

--- a/src/pages/QueriesPage.vue
+++ b/src/pages/QueriesPage.vue
@@ -204,7 +204,7 @@ async function executeQuery(details?: StatementToExecute) {
   }
 
   showResultPanel.value = true
-  await tabStore.executeQuery(activeTab.value.id, connId, sqlToExecute)
+  await tabStore.executeQuery(activeTab.value.id, sqlToExecute)
 }
 
 async function handleExplainQuery() {
@@ -216,7 +216,7 @@ function handleNewTab() {
   const db = connId
     ? (selectedDatabase.value || connectionStore.getCurrentDatabase(connId) || connectionStore.getConnectionById(connId)?.database || undefined)
     : undefined
-  tabStore.createTab(db, undefined, connId ?? undefined)
+  tabStore.createTab(connId ?? undefined, db)
 }
 
 function handleTabSelect(tabId: string) {
@@ -277,7 +277,7 @@ CREATE TABLE ${schemaPrefix}"${table.name}" (
 
   const connId = getActiveConnectionId()
   if (connId) {
-    const tab = tabStore.createTab(database, schema, connId)
+    const tab = tabStore.createTab(connId, database, schema)
     tabStore.updateTabContent(tab.id, script)
     tabStore.updateTabName(tab.id, `CREATE_${table.name}.sql`)
   }
@@ -289,11 +289,11 @@ function handleSelectTopN(table: TableInfo, database: string, schema?: string, n
 
   const connId = getActiveConnectionId()
   if (connId) {
-    const tab = tabStore.createTab(database, schema, connId)
+    const tab = tabStore.createTab(connId, database, schema)
     tabStore.updateTabContent(tab.id, query)
     tabStore.updateTabName(tab.id, `SELECT_${table.name}`)
 
-    tabStore.executeQuery(tab.id, connId)
+    tabStore.executeQuery(tab.id)
     showResultPanel.value = true
   }
 }
@@ -309,7 +309,7 @@ WHERE table_name = '${table.name}'${schema ? ` AND table_schema = '${schema}'` :
 
   const connId = getActiveConnectionId()
   if (connId) {
-    const tab = tabStore.createTab(database, schema, connId)
+    const tab = tabStore.createTab(connId, database, schema)
     tabStore.updateTabContent(tab.id, query)
     tabStore.updateTabName(tab.id, `STRUCTURE_${table.name}`)
   }
@@ -323,7 +323,7 @@ function handleSelectTable(table: TableInfo, database: string, schema?: string) 
   const connId = getActiveConnectionId()
   if (!connId)
     return
-  tabStore.openTableViewTab(database, table.name, schema, connId)
+  tabStore.openTableViewTab(connId, database, table.name, schema)
 }
 
 async function handleOpenSavedQuery(filePath: string) {
@@ -338,7 +338,7 @@ async function handleOpenSavedQuery(filePath: string) {
     ? (selectedDatabase.value || connectionStore.getCurrentDatabase(connId) || connectionStore.getConnectionById(connId)?.database || undefined)
     : undefined
 
-  const tab = tabStore.createTab(db, undefined, connId ?? undefined)
+  const tab = tabStore.createTab(connId ?? undefined, db)
 
   try {
     const result = await loadQueryFile(filePath)

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -75,7 +75,7 @@ export const useTabStore = defineStore('tabs', {
   },
 
   actions: {
-    createTab(database?: string, schema?: string, connectionId?: string): QueryTab {
+    createTab(connectionId?: string, database?: string, schema?: string): QueryTab {
       const tab: QueryTab = {
         id: generateId(),
         name: `Query ${this.tabs.length + 1}`,
@@ -91,7 +91,7 @@ export const useTabStore = defineStore('tabs', {
       return tab
     },
 
-    openTableViewTab(database: string, tableName: string, schema?: string, connectionId?: string): QueryTab {
+    openTableViewTab(connectionId: string, database: string, tableName: string, schema?: string): QueryTab {
       const existing = this.tabs.find(
         t => t.tableView
           && t.tableView.tableName === tableName
@@ -136,6 +136,14 @@ export const useTabStore = defineStore('tabs', {
     closeAllTabs() {
       this.tabs = []
       this.activeTabId = null
+    },
+
+    closeTabsForConnection(connectionId: string) {
+      const remaining = this.tabs.filter(t => t.connectionId !== connectionId)
+      this.tabs = remaining
+      if (this.activeTabId && !remaining.find(t => t.id === this.activeTabId)) {
+        this.activeTabId = remaining[0]?.id ?? null
+      }
     },
 
     closeNonOrphanTabs() {
@@ -233,7 +241,7 @@ export const useTabStore = defineStore('tabs', {
       }
     },
 
-    async executeQuery(tabId: string, activeConnectionId: string, sqlToExecute?: string) {
+    async executeQuery(tabId: string, sqlToExecute?: string) {
       const tab = this.tabs.find(t => t.id === tabId)
       if (!tab || tab.orphanFromConnectionId) {
         return
@@ -242,6 +250,11 @@ export const useTabStore = defineStore('tabs', {
       const sql = sqlToExecute !== undefined ? sqlToExecute : tab.content
 
       if (typeof sql !== 'string' || sql.trim() === '') {
+        return
+      }
+
+      const activeConnectionId = tab.connectionId
+      if (!activeConnectionId) {
         return
       }
 


### PR DESCRIPTION
## Why

CI has been red on `master` for all three platforms (macOS / Windows / Linux). The failing job is `npm run test:ci` in `tests/store/tabStore.test.ts` — 9 assertions across `createTab`, `openTableViewTab`, `closeTabsForConnection`, and `executeQuery`. The tests have always encoded the intended developer-facing API (connectionId first, dedicated bulk-close helper, executeQuery reading the connection from the tab itself), but the store implementation drifted to a connectionId-last shape and was missing `closeTabsForConnection` entirely.

This blocks PR #52 (transfer wiring) and the in-flight transfer redesign branch from landing green.

## What changed

`src/store/tabStore.ts`:
- `createTab(connectionId?, database?, schema?)` — was `(database?, schema?, connectionId?)`
- `openTableViewTab(connectionId, database, tableName, schema?)` — was `(database, tableName, schema?, connectionId?)`
- `executeQuery(tabId, sqlToExecute?)` — now reads `connectionId` from the tab itself; bails early if the tab has no connection. This matches every test in the suite (`store.executeQuery('tab-1')`).
- New `closeTabsForConnection(connectionId)` — filters out tabs belonging to a connection and reassigns the active tab when needed.

Callsites updated in `src/pages/QueriesPage.vue` (7 calls) and `src/pages/HistoryPage.vue` (1 call).

## Verification

- `npm run test:ci` — **276 / 276 passing** (was 267 / 276)
- `npm run lint:check` — clean (1 pre-existing warning in unrelated `ExportWizard.vue`, not touched here)
- `lsp_diagnostics` clean on all three touched files

## Scope discipline

Per AGENTS.md "bugfix minimally" — this PR only changes signatures + adds the missing method + updates direct callsites. No behavior changes beyond what the tests already specified. No refactors. No unrelated cleanup.