### PR TITLE
feat: HTTP proxy configuration for LLM provider connections (#74)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -217,7 +217,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2751,7 +2750,6 @@
       "integrity": "sha512-PsSugIf9ip1H/mWKj4bi/BlEoerxXAda9ByRFsYuwsmr6af9NxJL0AaiNXs8Le7R21QR5KMiD/KdxZZ71LjAxQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/types": "^8.52.0",
@@ -3278,7 +3276,6 @@
       "integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.53.0",
@@ -3308,7 +3305,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3603,7 +3599,6 @@
       "integrity": "sha512-6i+kNVVGb5I+XOCUgLDHol6sxb28ahbJrmLL/eiAWflT850MUqtAlFeyHDYHzScnOFcPy1AcmeY0yM77GgERmg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.53.0",
         "@unocss/config": "66.6.0",
@@ -4329,7 +4324,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
       "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.26",
@@ -4521,7 +4515,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4849,7 +4842,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5635,7 +5627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5866,7 +5857,6 @@
       "integrity": "sha512-nK96Gnt6/9wj8KhTFg+D80Mc01cffrcB15NO6pkTJmPpO0vHV+9yxegr+wVry4O3uGbu83HN86inCO3IsML9Rw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dprint/formatter": "^0.5.1",
         "@dprint/markdown": "^0.20.0",
@@ -7307,7 +7297,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7888,7 +7877,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7988,7 +7976,6 @@
       "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -9648,7 +9635,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -11025,7 +11011,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11170,7 +11155,6 @@
       "integrity": "sha512-B5QsMJzFKeTHPzF5Ehr8tSMuhxzbCR9n+XP0GyhK9/2jTcBdI0/T+rCDDr9m6vUz+lku/coCVz7VAQ2BRAbZJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@unocss/astro": "66.6.0",
         "@unocss/cli": "66.6.0",
@@ -11360,7 +11344,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11442,7 +11425,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",
@@ -11465,7 +11447,6 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,7 +69,8 @@ calamine = "0.22"
 async-openai = "0.25"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
-  "native-tls"
+  "native-tls",
+  "socks"
 ] }
 tiktoken-rs = "0.5"
 http = "1"

--- a/src-tauri/src/agent/compact.rs
+++ b/src-tauri/src/agent/compact.rs
@@ -203,7 +203,7 @@ pub async fn summarize_with_llm(
     let proxy_mode = settings
         .get("proxyMode")
         .and_then(|v| v.as_str())
-        .unwrap_or("system");
+        .unwrap_or("none");
     let http_client = create_http_client(proxy_mode, http_proxy, None, None);
 
     let resp = post_chat_completions_compact(&http_client, &base_url, headers, body).await?;

--- a/src-tauri/src/agent/harness.rs
+++ b/src-tauri/src/agent/harness.rs
@@ -179,6 +179,8 @@ pub async fn run_agent_step(
                 &tools,
                 &resolved_base,
                 &api_key,
+                http_proxy.as_deref(),
+                proxy_mode.as_deref(),
             )
             .await
         }
@@ -304,10 +306,12 @@ async fn run_anthropic(
     tools: &[Value],
     base_url: &str,
     api_key: &str,
+    http_proxy: Option<&str>,
+    proxy_mode: Option<&str>,
 ) -> Result<Value, String> {
     let client = create_http_client(
-        "none",
-        None,
+        proxy_mode.unwrap_or("none"),
+        http_proxy.map(|s| s.to_string()),
         None,
         Some(std::time::Duration::from_secs(300)),
     );
@@ -503,7 +507,7 @@ pub async fn validate_llm_config(
     let resolved_base = base_url
         .filter(|u| !u.is_empty())
         .unwrap_or_else(|| provider_adapter::default_base_url(api_compat));
-    let client = create_http_client(&proxy_mode.unwrap_or_default(), http_proxy, None, None);
+    let client = create_http_client(&proxy_mode.as_deref().unwrap_or("none"), http_proxy, None, None);
     match api_compat {
         "anthropic" => {
             let url = format!(
@@ -545,14 +549,22 @@ pub async fn list_llm_models(
     provider: String,
     api_key: String,
     base_url: Option<String>,
+    http_proxy: Option<String>,
+    proxy_mode: Option<String>,
 ) -> Result<Vec<String>, String> {
     let api_compat = provider_adapter::map_to_api_compatibility(&provider);
     let resolved_base = base_url
         .filter(|u| !u.is_empty())
         .unwrap_or_else(|| provider_adapter::default_base_url(api_compat));
-    let models = model_registry::get_provider_model_list(api_compat, &resolved_base, &api_key)
-        .await
-        .map_err(|e| sanitize_error(&e))?;
+    let models = model_registry::get_provider_model_list(
+        api_compat,
+        &resolved_base,
+        &api_key,
+        http_proxy,
+        &proxy_mode.unwrap_or_else(|| String::from("none")),
+    )
+    .await
+    .map_err(|e| sanitize_error(&e))?;
     Ok(models
         .into_iter()
         .filter_map(|m| {

--- a/src-tauri/src/agent/loop_runner.rs
+++ b/src-tauri/src/agent/loop_runner.rs
@@ -497,6 +497,8 @@ pub async fn run_agent_loop(
     let api_key = get_settings_str(&settings, "apiKey").unwrap_or_default();
     let api_compat =
         get_settings_str(&settings, "apiCompatibility").unwrap_or_else(|| String::from("openai"));
+    let proxy_url = get_settings_str(&settings, "httpProxy");
+    let proxy_mode = get_settings_str(&settings, "proxyMode").unwrap_or_else(|| String::from("none"));
     let formatter: Box<dyn ChatFormatter> = if api_compat == "anthropic" {
         Box::new(AnthropicChatFormatter)
     } else {
@@ -861,7 +863,7 @@ pub async fn run_agent_loop(
             });
             h
         };
-        let client = create_http_client("system", None, Some(true), Some(Duration::from_secs(300)));
+        let client = create_http_client(&proxy_mode, proxy_url.clone(), Some(true), Some(Duration::from_secs(300)));
 
         // Reset accumulated content for this iteration
         accumulated_content.clear();
@@ -1728,6 +1730,8 @@ async fn run_agent_loop_inner(
     let api_key = get_settings_str(settings, "apiKey").unwrap_or_default();
     let api_compat =
         get_settings_str(settings, "apiCompatibility").unwrap_or_else(|| String::from("openai"));
+    let proxy_url = get_settings_str(settings, "httpProxy");
+    let proxy_mode = get_settings_str(settings, "proxyMode").unwrap_or_else(|| String::from("none"));
     let formatter: Box<dyn ChatFormatter> = if api_compat == "anthropic" {
         Box::new(AnthropicChatFormatter)
     } else {
@@ -1956,7 +1960,7 @@ async fn run_agent_loop_inner(
             });
             h
         };
-        let client = create_http_client("system", None, Some(true), Some(Duration::from_secs(300)));
+        let client = create_http_client(&proxy_mode, proxy_url.clone(), Some(true), Some(Duration::from_secs(300)));
 
         let mut assistant_content = String::new();
         let mut tool_calls_this_turn: Vec<LlmToolCall> = Vec::new();

--- a/src-tauri/src/agent/model_registry.rs
+++ b/src-tauri/src/agent/model_registry.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::common::http_client::create_http_client;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TokenizerFamily {
     OpenAiCl100k,
@@ -147,6 +149,8 @@ pub async fn get_provider_model_list(
     api_compat: &str,
     base_url: &str,
     api_key: &str,
+    proxy_url: Option<String>,
+    proxy_mode: &str,
 ) -> Result<Vec<serde_json::Value>, String> {
     if api_key.is_empty() {
         return Ok(default_models_for_api(api_compat)
@@ -165,10 +169,7 @@ pub async fn get_provider_model_list(
         _ => format!("{}/models", base_url.trim_end_matches('/')),
     };
 
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| e.to_string())?;
+    let client = create_http_client(proxy_mode, proxy_url, Some(true), None);
 
     let response = client
         .get(&url)

--- a/src/composables/useChatAgent.ts
+++ b/src/composables/useChatAgent.ts
@@ -320,6 +320,8 @@ export function useChatAgent(config: UseChatAgentConfig) {
         model: modelConfig.model.label,
         baseUrl: modelConfig.provider.baseUrl,
         apiKey: modelConfig.provider.apiKey,
+        httpProxy: modelConfig.provider.proxy,
+        proxyMode: modelConfig.provider.proxyMode ?? 'none',
         tools: runtime?.tools ?? [],
         toolMetadata: runtime?.toolMetadata ?? {},
         maxIterations: activeSession.value?.maxIterations ?? 25,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -349,6 +349,8 @@ export const useAppStore = defineStore('app', {
           provider: provider.apiCompatibility,
           apiKey: provider.apiKey,
           baseUrl: provider.baseUrl || null,
+          httpProxy: provider.proxy || null,
+          proxyMode: provider.proxyMode || 'none',
         })
         if (models.length > 0) {
           const updated = [...this.llmSettings.providers]


### PR DESCRIPTION
## Summary

Implements HTTP proxy configuration for LLM provider connections in SQLKit, matching the dockit implementation approach.

Closes #74

## Changes

### Frontend
- **useChatAgent.ts**: Include `httpProxy`/`proxyMode` in agent loop settings payload so proxy config flows to `run_agent_loop`
- **appStore.ts**: Pass `httpProxy`/`proxyMode` when syncing provider models via `list_llm_models`

### Backend
- **loop_runner.rs**: Extract `httpProxy`/`proxyMode` from settings and pass to `create_http_client()` in both `run_agent_loop` and `run_agent_loop_inner`
- **harness.rs**: Pass proxy params to `run_anthropic` (was hardcoded to `"none"`); accept proxy params in `list_llm_models`; fix `validate_llm_config` default from `unwrap_or_default()` to `unwrap_or("none")`
- **model_registry.rs**: Use `create_http_client()` instead of hardcoded `.no_proxy().build()` in `get_provider_model_list`
- **compact.rs**: Align proxy_mode default from `"system"` to `"none"` for consistency
- **Cargo.toml**: Enable `socks` feature on reqwest for SOCKS5 proxy support

### Already existed (no changes needed)
- `LlmProvider` type already has `proxy`/`proxyMode` fields
- `provider-form-dialog.vue` already has proxy mode selector (None/System/Manual) + URL input
- `common/http_client.rs` already supports 3 proxy modes with env var fallback
- i18n keys already exist in enUS and zhCN

## Proxy Modes
| Mode | Behavior |
|------|----------|
| None | Direct connection (`.no_proxy()`) |
| System | Uses OS proxy settings / env vars |
| Manual | Explicit proxy URL — supports `http://` and `socks5://` |

## Environment Variable Fallback
`HTTPS_PROXY` → `https_proxy` → `HTTP_PROXY` → `http_proxy` → `all_proxy`

## Testing
- Rust: `cargo check --no-default-features` passes (preexisting duckdb C++ build issue in default features)
- Frontend: `vue-tsc --noEmit` and ESLint pass
- All 7 `create_http_client` LLM call sites verified proxy-aware by Oracle review