### PR TITLE
feat: inline row data search across all columns in table view

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
       - name: Check if version is new
         id: check
         run: |

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -4,7 +4,8 @@
 //! including databases, schemas, tables, columns, and table data.
 
 use crate::database::{
-    ColumnInfo, DatabaseAdapter, DatabaseSchema, MySQLAdapter, PostgresAdapter, QueryResult, SqlServerAdapter, TableInfo,
+    search, ColumnInfo, DatabaseAdapter, DatabaseSchema, MySQLAdapter, PostgresAdapter,
+    QueryResult, SqlServerAdapter, TableInfo,
 };
 use crate::state::{ActiveConnection, AppState};
 use serde::{Deserialize, Serialize};
@@ -1093,6 +1094,135 @@ fn extract_count(result: QueryResult) -> Result<u64, String> {
             _ => None,
         })
         .ok_or_else(|| "Failed to extract row count from query result".to_string())
+}
+
+/// Map an [`ActiveConnection`] variant to the db_type string used by
+/// [`quote_identifier`] and [`search::build_table_search_where`].
+fn get_db_type_string(connection: &ActiveConnection) -> &'static str {
+    match connection {
+        ActiveConnection::Postgres(_) => "postgres",
+        ActiveConnection::MySQL(_) => "mysql",
+        ActiveConnection::SQLServer(_) => "sqlserver",
+        ActiveConnection::SQLite(_) => "sqlite",
+        ActiveConnection::DuckDb(_) => "duckdb",
+        ActiveConnection::ClickHouse(_) => "clickhouse",
+        ActiveConnection::JdbcBridge(_) => "jdbc",
+        ActiveConnection::HttpSql(_) => "trino",
+    }
+}
+
+/// Build a SQL WHERE clause that searches across all text and numeric columns in a table.
+///
+/// The generated WHERE clause uses dialect-aware casting and LIKE matching,
+/// skipping BLOB/BINARY/geometry columns entirely. The frontend can pass the
+/// returned string as the `filter` parameter to [`get_table_data`] and [`get_table_count`]
+/// to show only matching rows.
+///
+/// # Arguments
+///
+/// * `connection_id` - ID of the active connection
+/// * `database` - Database name containing the table
+/// * `schema` - Optional schema name (PostgreSQL, SQL Server)
+/// * `table_name` - Table name to search
+/// * `search_term` - The user's search term
+/// * `state` - Application state
+///
+/// # Returns
+///
+/// A WHERE clause string like `(LOWER(CAST("col1" AS TEXT)) LIKE '%term%' OR ...)`,
+/// or an empty string if no searchable columns are found.
+#[tauri::command]
+pub async fn build_table_search_filter(
+    connection_id: String,
+    database: String,
+    schema: Option<String>,
+    table_name: String,
+    search_term: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let connections = state.connections.lock().await;
+    let connection = connections
+        .get(&connection_id)
+        .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?;
+
+    let db_type = get_db_type_string(connection);
+
+    let columns = match connection {
+        ActiveConnection::Postgres(adapter) => {
+            let adapter = adapter.lock().await;
+            if Some(database.as_str()) != adapter.config.database.as_deref() {
+                let mut temp_config = adapter.config.clone();
+                drop(adapter);
+                temp_config.database = Some(database.clone());
+                let mut temp = PostgresAdapter::new(temp_config);
+                temp.connect()
+                    .await
+                    .map_err(|e| format!("Failed to connect to database '{}': {}", database, e))?;
+                temp.list_columns(None, schema.as_deref(), &table_name)
+                    .await
+            } else {
+                adapter
+                    .list_columns(None, schema.as_deref(), &table_name)
+                    .await
+            }
+        }
+        ActiveConnection::MySQL(adapter) => {
+            let adapter = adapter.lock().await;
+            adapter
+                .list_columns(Some(&database), None, &table_name)
+                .await
+        }
+        ActiveConnection::SQLServer(adapter) => {
+            let adapter = adapter.lock().await;
+            if Some(database.as_str()) != adapter.config.database.as_deref() {
+                let mut temp_config = adapter.config.clone();
+                drop(adapter);
+                temp_config.database = Some(database.clone());
+                let mut temp = SqlServerAdapter::new(temp_config);
+                temp.connect()
+                    .await
+                    .map_err(|e| format!("Failed to connect to database '{}': {}", database, e))?;
+                temp.list_columns(None, schema.as_deref(), &table_name)
+                    .await
+            } else {
+                adapter
+                    .list_columns(None, schema.as_deref(), &table_name)
+                    .await
+            }
+        }
+        ActiveConnection::SQLite(adapter) => {
+            let adapter = adapter.lock().await;
+            adapter.list_columns(None, None, &table_name).await
+        }
+        ActiveConnection::DuckDb(adapter) => {
+            let adapter = adapter.lock().await;
+            adapter
+                .list_columns(None, schema.as_deref(), &table_name)
+                .await
+        }
+        ActiveConnection::ClickHouse(adapter) => {
+            let adapter = adapter.lock().await;
+            adapter
+                .list_columns(Some(&database), None, &table_name)
+                .await
+        }
+        ActiveConnection::JdbcBridge(adapter) => {
+            let adapter = adapter.lock().await;
+            adapter
+                .list_columns(None, schema.as_deref(), &table_name)
+                .await
+        }
+        ActiveConnection::HttpSql(adapter) => {
+            let adapter = adapter.lock().await;
+            adapter
+                .list_columns(None, schema.as_deref(), &table_name)
+                .await
+        }
+    }
+    .map_err(|e| format!("Failed to list columns for search: {}", e))?;
+
+    let where_clause = search::build_table_search_where(db_type, &columns, &search_term);
+    Ok(where_clause.unwrap_or_default())
 }
 
 // Tests for browse commands are temporarily disabled.

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -70,6 +70,7 @@ pub mod manager;
 pub mod mysql;
 pub mod pool;
 pub mod postgres;
+pub mod search;
 pub mod sqlite;
 pub mod sqlserver;
 pub mod strategy;

--- a/src-tauri/src/database/search.rs
+++ b/src-tauri/src/database/search.rs
@@ -1,0 +1,677 @@
+//! Search SQL generation for inline row data search across all columns.
+//!
+//! This module provides functions to build dialect-aware search WHERE clauses
+//! for searching across text and numeric columns in a table. BLOB/BINARY/geometry
+//! columns are automatically skipped.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use sqlkit::database::search::build_table_search_where;
+//!
+//! let columns = vec![
+//!     ColumnInfo { name: "email".into(), data_type: "varchar".into(), .. },
+//!     ColumnInfo { name: "age".into(), data_type: "integer".into(), .. },
+//! ];
+//!
+//! let where_clause = build_table_search_where("postgres", &columns, "alice");
+//! // Returns: (LOWER(CAST("email" AS TEXT)) LIKE '%alice%' OR LOWER(CAST("age" AS TEXT)) LIKE '%alice%' OR "age" = 42)
+//! ```
+
+use crate::database::types::ColumnInfo;
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+/// Category of a column type for search purposes.
+///
+/// Determines how a column is searched:
+/// - `Text`: searched with `LOWER(CAST(col AS TYPE)) LIKE '%term%'`
+/// - `Numeric`: searched with both exact equality and text LIKE
+/// - `Skip`: excluded entirely from search (BLOB/BINARY/geometry)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnCategory {
+    /// Text-type column — use LIKE on cast-to-text.
+    Text,
+    /// Numeric-type column — use equality AND LIKE on cast-to-text.
+    Numeric,
+    /// Binary/geometry column — skip from search.
+    Skip,
+}
+
+/// Classify a column data type string into a [`ColumnCategory`].
+///
+/// Matches common type names across PostgreSQL, MySQL, SQL Server, and SQLite.
+///
+/// # Classification Rules
+///
+/// | Category | Matches |
+/// |---|---|
+/// | `Skip` | blob, binary, bytea, varbinary, image, geometry, geography, point, linestring, polygon, circle, box, path, pgis_* |
+/// | `Numeric` | int*, serial*, numeric*, decimal*, float*, double*, real*, money*, number, bool, boolean, bit |
+/// | `Text` | Everything else (char, varchar, text, uuid, enum, json, jsonb, xml, date/time types, etc.) |
+pub fn classify_column(col_type: &str) -> ColumnCategory {
+    let t = col_type.to_lowercase();
+
+    // Skip types — BLOB, BINARY, GEOMETRY, interval (time range), etc.
+    if t.contains("blob")
+        || t.contains("binary")
+        || t.contains("bytea")
+        || t.contains("varbinary")
+        || t.contains("image")
+        || t.contains("geometry")
+        || t.contains("geography")
+        || t.contains("point")
+        || t.contains("linestring")
+        || t.contains("polygon")
+        || t.contains("circle")
+        || t.contains("box")
+        || t.contains("path")
+        || t == "interval"
+        || t.starts_with("pgis_")
+    {
+        return ColumnCategory::Skip;
+    }
+
+    // Numeric types
+    if t.contains("int")
+        || t.contains("serial")
+        || t.contains("numeric")
+        || t.contains("decimal")
+        || t.contains("float")
+        || t.contains("double")
+        || t.contains("real")
+        || t.contains("money")
+        || t.contains("number")
+        || t == "bool"
+        || t == "boolean"
+        || t == "bit"
+    {
+        return ColumnCategory::Numeric;
+    }
+
+    // Everything else is searchable as text
+    ColumnCategory::Text
+}
+
+/// Get the target type name for `CAST(col AS <type>)` in a given database dialect.
+fn cast_target_type(db_type: &str) -> &'static str {
+    match db_type {
+        "postgres" | "duckdb" | "sqlite" => "TEXT",
+        "mysql" | "clickhouse" => "CHAR",
+        "sqlserver" => "NVARCHAR(MAX)",
+        "jdbc" | "trino" => "VARCHAR",
+        _ => "TEXT",
+    }
+}
+
+/// Quote a SQL identifier according to the database dialect.
+///
+/// Supports the same dialects as `crate::commands::browse::quote_identifier`.
+fn quote_identifier(identifier: &str, db_type: &str) -> String {
+    match db_type {
+        "postgres" | "sqlite" | "duckdb" | "jdbc" => {
+            format!("\"{}\"", identifier.replace('\"', "\"\""))
+        }
+        "mysql" | "clickhouse" => format!("`{}`", identifier.replace('`', "``")),
+        "sqlserver" => format!("[{}]", identifier.replace(']', "]]")),
+        _ => identifier.to_string(),
+    }
+}
+
+/// Build a search WHERE clause that searches across all non-BLOB columns.
+///
+/// Returns `None` if the search term is empty or no searchable columns are found.
+///
+/// # Search Behavior
+///
+/// - **Text columns** (`ColumnCategory::Text`): matched with
+///   `LOWER(CAST(col AS type)) LIKE '%term%'`
+/// - **Numeric columns** (`ColumnCategory::Numeric`): matched with
+///   `(col = term OR LOWER(CAST(col AS type)) LIKE '%term%')` — this handles
+///   both exact numeric matches and text representation matches
+/// - **Skip columns** (`ColumnCategory::Skip`): excluded entirely
+/// - The search is **case-insensitive** via `LOWER()`
+///
+/// # Arguments
+///
+/// * `db_type` - Database type string (`"postgres"`, `"mysql"`, `"sqlserver"`, `"sqlite"`, etc.)
+/// * `columns` - Column metadata from `list_columns` or `get_table_info`
+/// * `term` - The raw user search term (will be trimmed)
+///
+/// # Returns
+///
+/// An SQL WHERE clause like `(LOWER(CAST("col1" AS TEXT)) LIKE '%term%' OR ...)`
+/// or `None` if no searchable columns or empty term.
+pub fn build_table_search_where(db_type: &str, columns: &[ColumnInfo], term: &str) -> Option<String> {
+    let term = term.trim();
+    if term.is_empty() {
+        return None;
+    }
+
+    let searchable: Vec<&ColumnInfo> = columns
+        .iter()
+        .filter(|c| classify_column(&c.data_type) != ColumnCategory::Skip)
+        .collect();
+
+    if searchable.is_empty() {
+        return None;
+    }
+
+    let cast_type = cast_target_type(db_type);
+    let escaped_term = term.replace('\'', "''");
+    let lower_term = escaped_term.to_lowercase();
+
+    let conditions: Vec<String> = searchable
+        .iter()
+        .map(|col| {
+            let quoted = quote_identifier(&col.name, db_type);
+            let category = classify_column(&col.data_type);
+            let text_condition =
+                format!("LOWER(CAST({} AS {})) LIKE '%{}%'", quoted, cast_type, lower_term);
+
+            match category {
+                ColumnCategory::Text => text_condition,
+                ColumnCategory::Numeric => {
+                    // Try exact numeric match; if term is a valid number, include equality
+                    if term.parse::<f64>().is_ok() {
+                        format!("{} = {} OR {}", quoted, term, text_condition)
+                    } else {
+                        // Not a number — only text search
+                        text_condition
+                    }
+                }
+                ColumnCategory::Skip => unreachable!(), // filtered above
+            }
+        })
+        .collect();
+
+    if conditions.is_empty() {
+        return None;
+    }
+
+    Some(format!("({})", conditions.join(" OR ")))
+}
+
+/// Generate a stable WHERE clause that uniquely identifies a row.
+///
+/// Uses primary key columns if available; otherwise falls back to matching
+/// all searchable (non-BLOB) column values. Intended for future "open filtered
+/// from search" navigation — the caller can append this to a SELECT to
+/// jump directly to the row that was clicked in the search results.
+///
+/// # Arguments
+///
+/// * `db_type` - Database type string (`"postgres"`, `"mysql"`, etc.)
+/// * `columns` - Column metadata for the table (used to find PKs)
+/// * `row_values` - A single row's data as column → JSON value map
+///
+/// # Returns
+///
+/// A WHERE clause like `"id" = 42 AND "name" = 'alice'`, or `None` if
+/// `row_values` is empty or no suitable columns are found.
+pub fn build_search_result_where(
+    db_type: &str,
+    columns: &[ColumnInfo],
+    row_values: &HashMap<String, JsonValue>,
+) -> Option<String> {
+    if row_values.is_empty() {
+        return None;
+    }
+
+    // Prefer primary key columns for stable row identification.
+    let pk_cols: Vec<&ColumnInfo> = columns.iter().filter(|c| c.is_primary_key).collect();
+    let target_cols: Vec<&ColumnInfo> = if !pk_cols.is_empty() {
+        pk_cols
+    } else {
+        // Fall back to all searchable (non-BLOB) columns
+        columns
+            .iter()
+            .filter(|c| classify_column(&c.data_type) != ColumnCategory::Skip)
+            .collect()
+    };
+
+    let conditions: Vec<String> = target_cols
+        .iter()
+        .filter_map(|col| {
+            let value = row_values.get(&col.name)?;
+            let quoted = quote_identifier(&col.name, db_type);
+            if value.is_null() {
+                Some(format!("{} IS NULL", quoted))
+            } else {
+                Some(format!("{} = {}", quoted, json_to_sql_literal(value)))
+            }
+        })
+        .collect();
+
+    if conditions.is_empty() {
+        return None;
+    }
+    Some(conditions.join(" AND "))
+}
+
+/// Convert a `serde_json::Value` to a SQL literal string.
+fn json_to_sql_literal(val: &JsonValue) -> String {
+    match val {
+        JsonValue::Null => "NULL".to_string(),
+        JsonValue::Bool(b) => {
+            if *b {
+                "TRUE".to_string()
+            } else {
+                "FALSE".to_string()
+            }
+        }
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::String(s) => format!("'{}'", s.replace('\'', "''")),
+        JsonValue::Array(_) | JsonValue::Object(_) => {
+            let s = val.to_string().replace('\'', "''");
+            format!("'{}'", s)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn col(name: &str, data_type: &str) -> ColumnInfo {
+        ColumnInfo {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            nullable: true,
+            default_value: None,
+            is_primary_key: false,
+            is_auto_increment: false,
+            max_length: None,
+            precision: None,
+            scale: None,
+            description: None,
+            metadata: std::collections::HashMap::new(),
+        }
+    }
+
+    // ── classify_column tests ──
+
+    #[test]
+    fn test_classify_text_types() {
+        for t in &["varchar", "char", "text", "nvarchar", "nchar", "ntext", "uuid", "enum",
+                     "name", "json", "jsonb", "xml", "date", "time", "timestamp", "timestamptz",
+                     "bpchar"]
+        {
+            assert_eq!(
+                classify_column(t),
+                ColumnCategory::Text,
+                "expected '{}' to be Text",
+                t,
+            );
+        }
+    }
+
+    #[test]
+    fn test_classify_numeric_types() {
+        for t in &["integer", "int", "int4", "int8", "int16", "bigint", "smallint", "tinyint",
+                     "serial", "bigserial", "smallserial", "numeric", "decimal", "float", "float4",
+                     "float8", "double", "double precision", "real", "money", "smallmoney",
+                     "number", "bool", "boolean", "bit"]
+        {
+            assert_eq!(
+                classify_column(t),
+                ColumnCategory::Numeric,
+                "expected '{}' to be Numeric",
+                t,
+            );
+        }
+    }
+
+    #[test]
+    fn test_classify_skip_types() {
+        for t in &["blob", "binary", "bytea", "varbinary", "image", "geometry", "geography",
+                     "point", "linestring", "polygon", "circle", "box", "path", "interval"]
+        {
+            assert_eq!(
+                classify_column(t),
+                ColumnCategory::Skip,
+                "expected '{}' to be Skip",
+                t,
+            );
+        }
+    }
+
+    #[test]
+    fn test_classify_case_insensitive() {
+        assert_eq!(classify_column("VARCHAR"), ColumnCategory::Text);
+        assert_eq!(classify_column("INTEGER"), ColumnCategory::Numeric);
+        assert_eq!(classify_column("BLOB"), ColumnCategory::Skip);
+        assert_eq!(classify_column("Text"), ColumnCategory::Text);
+        assert_eq!(classify_column("Bytea"), ColumnCategory::Skip);
+    }
+
+    // ── build_table_search_where tests ──
+
+    #[test]
+    fn test_empty_term_returns_none() {
+        let cols = [col("id", "integer")];
+        assert_eq!(build_table_search_where("postgres", &cols, ""), None);
+        assert_eq!(build_table_search_where("postgres", &cols, "  "), None);
+    }
+
+    #[test]
+    fn test_no_searchable_columns_returns_none() {
+        let cols = [col("data", "blob")];
+        assert_eq!(build_table_search_where("postgres", &cols, "test"), None);
+    }
+
+    #[test]
+    fn test_postgres_text_search() {
+        let cols = [col("name", "varchar"), col("email", "text")];
+        let result = build_table_search_where("postgres", &cols, "alice").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(\"name\" AS TEXT)) LIKE '%alice%' OR LOWER(CAST(\"email\" AS TEXT)) LIKE '%alice%')"
+        );
+    }
+
+    #[test]
+    fn test_postgres_numeric_search() {
+        let cols = [col("age", "integer")];
+        let result = build_table_search_where("postgres", &cols, "42").unwrap();
+        assert_eq!(
+            result,
+            "(\"age\" = 42 OR LOWER(CAST(\"age\" AS TEXT)) LIKE '%42%')"
+        );
+    }
+
+    #[test]
+    fn test_postgres_numeric_search_non_numeric_term() {
+        let cols = [col("age", "integer")];
+        // "abc" is not a valid number, so only text search
+        let result = build_table_search_where("postgres", &cols, "abc").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(\"age\" AS TEXT)) LIKE '%abc%')"
+        );
+    }
+
+    #[test]
+    fn test_postgres_mixed_search() {
+        let cols = [
+            col("name", "varchar"),
+            col("age", "integer"),
+            col("avatar", "bytea"), // skipped
+        ];
+        let result = build_table_search_where("postgres", &cols, "42").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(\"name\" AS TEXT)) LIKE '%42%' OR \"age\" = 42 OR LOWER(CAST(\"age\" AS TEXT)) LIKE '%42%')"
+        );
+    }
+
+    #[test]
+    fn test_mysql_text_search() {
+        let cols = [col("name", "varchar")];
+        let result = build_table_search_where("mysql", &cols, "alice").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(`name` AS CHAR)) LIKE '%alice%')"
+        );
+    }
+
+    #[test]
+    fn test_mysql_numeric_search() {
+        let cols = [col("age", "int")];
+        let result = build_table_search_where("mysql", &cols, "42").unwrap();
+        assert_eq!(
+            result,
+            "(`age` = 42 OR LOWER(CAST(`age` AS CHAR)) LIKE '%42%')"
+        );
+    }
+
+    #[test]
+    fn test_sqlserver_text_search() {
+        let cols = [col("name", "nvarchar")];
+        let result = build_table_search_where("sqlserver", &cols, "alice").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST([name] AS NVARCHAR(MAX))) LIKE '%alice%')"
+        );
+    }
+
+    #[test]
+    fn test_sqlserver_numeric_search() {
+        let cols = [col("age", "int")];
+        let result = build_table_search_where("sqlserver", &cols, "42").unwrap();
+        assert_eq!(
+            result,
+            "([age] = 42 OR LOWER(CAST([age] AS NVARCHAR(MAX))) LIKE '%42%')"
+        );
+    }
+
+    #[test]
+    fn test_sqlite_text_search() {
+        let cols = [col("name", "text")];
+        let result = build_table_search_where("sqlite", &cols, "alice").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(\"name\" AS TEXT)) LIKE '%alice%')"
+        );
+    }
+
+    #[test]
+    fn test_duckdb_search() {
+        let cols = [col("name", "varchar")];
+        let result = build_table_search_where("duckdb", &cols, "test").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(\"name\" AS TEXT)) LIKE '%test%')"
+        );
+    }
+
+    #[test]
+    fn test_clickhouse_search() {
+        let cols = [col("name", "String")];
+        let result = build_table_search_where("clickhouse", &cols, "test").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(`name` AS CHAR)) LIKE '%test%')"
+        );
+    }
+
+    #[test]
+    fn test_jdbc_search() {
+        let cols = [col("name", "varchar")];
+        let result = build_table_search_where("jdbc", &cols, "test").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(\"name\" AS VARCHAR)) LIKE '%test%')"
+        );
+    }
+
+    #[test]
+    fn test_trino_search() {
+        let cols = [col("name", "varchar")];
+        let result = build_table_search_where("trino", &cols, "test").unwrap();
+        // Trino does not quote identifiers by default
+        assert_eq!(
+            result,
+            "(LOWER(CAST(name AS VARCHAR)) LIKE '%test%')"
+        );
+    }
+
+    #[test]
+    fn test_special_chars_escaped() {
+        let cols = [col("name", "text")];
+        // Single quotes must be escaped
+        let result = build_table_search_where("postgres", &cols, "o'neil").unwrap();
+        assert_eq!(
+            result,
+            "(LOWER(CAST(\"name\" AS TEXT)) LIKE '%o''neil%')"
+        );
+    }
+
+    #[test]
+    fn test_column_with_special_chars() {
+        let cols = [col("last\"name", "text")];
+        let result = build_table_search_where("postgres", &cols, "test").unwrap();
+        // Quote in column name should be escaped
+        assert!(result.contains("\"last\"\"name\""));
+    }
+
+    #[test]
+    fn test_many_columns() {
+        let cols = (0..10)
+            .map(|i| col(&format!("col{}", i), "text"))
+            .collect::<Vec<_>>();
+        let result = build_table_search_where("postgres", &cols, "search").unwrap();
+        // Should contain 10 conditions
+        assert_eq!(result.matches("LOWER(CAST(").count(), 10);
+    }
+
+    #[test]
+    fn test_case_insensitive_search() {
+        let cols = [col("name", "varchar")];
+        let result = build_table_search_where("postgres", &cols, "ALICE").unwrap();
+        // The search term should be lowercased in the SQL
+        assert!(
+            result.contains("'%alice%'"),
+            "Expected lowercased term in LIKE, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_quote_identifier_postgres() {
+        assert_eq!(quote_identifier("test", "postgres"), "\"test\"");
+        assert_eq!(quote_identifier("te\"st", "postgres"), "\"te\"\"st\"");
+    }
+
+    #[test]
+    fn test_quote_identifier_mysql() {
+        assert_eq!(quote_identifier("test", "mysql"), "`test`");
+        assert_eq!(quote_identifier("te`st", "mysql"), "`te``st`");
+    }
+
+    #[test]
+    fn test_quote_identifier_sqlserver() {
+        assert_eq!(quote_identifier("test", "sqlserver"), "[test]");
+        assert_eq!(quote_identifier("te]st", "sqlserver"), "[te]]st]");
+    }
+
+    #[test]
+    fn test_quote_identifier_sqlite() {
+        assert_eq!(quote_identifier("test", "sqlite"), "\"test\"");
+    }
+
+    #[test]
+    fn test_classify_unknown_type_as_text() {
+        // Unknown or custom types should default to Text
+        assert_eq!(classify_column("custom_type"), ColumnCategory::Text);
+        assert_eq!(classify_column("hstore"), ColumnCategory::Text);
+        assert_eq!(classify_column("citext"), ColumnCategory::Text);
+    }
+
+    // ── build_search_result_where tests ──
+
+    fn pk_col(name: &str, data_type: &str) -> ColumnInfo {
+        ColumnInfo {
+            is_primary_key: true,
+            ..col(name, data_type)
+        }
+    }
+
+    fn row(pairs: &[(&str, JsonValue)]) -> HashMap<String, JsonValue> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+    }
+
+    #[test]
+    fn test_result_where_with_pk() {
+        let cols = [pk_col("id", "integer"), col("name", "varchar")];
+        let r = row(&[("id", json!(42)), ("name", json!("alice"))]);
+        let result = build_search_result_where("postgres", &cols, &r).unwrap();
+        assert_eq!(result, "\"id\" = 42");
+    }
+
+    #[test]
+    fn test_result_where_no_pk_fallback() {
+        let cols = [col("name", "varchar"), col("age", "integer"), col("avatar", "bytea")];
+        let r = row(&[("name", json!("alice")), ("age", json!(30)), ("avatar", json!(null))]);
+        let result = build_search_result_where("postgres", &cols, &r).unwrap();
+        // Should use name and age (searchable), skip bytea
+        assert!(result.contains("\"name\" = 'alice'"));
+        assert!(result.contains("\"age\" = 30"));
+        assert!(!result.contains("avatar"));
+        assert!(result.contains(" AND "));
+    }
+
+    #[test]
+    fn test_result_where_mixed_pk_and_regular() {
+        let cols = [pk_col("id", "int"), pk_col("lang", "varchar"), col("name", "text")];
+        let r = row(&[("id", json!(1)), ("lang", json!("en")), ("name", json!("hello"))]);
+        let result = build_search_result_where("postgres", &cols, &r).unwrap();
+        // Only PKs should be used
+        assert!(result.contains("\"id\" = 1"));
+        assert!(result.contains("\"lang\" = 'en'"));
+        assert!(!result.contains("name"));
+    }
+
+    #[test]
+    fn test_result_where_empty_row_returns_none() {
+        let cols = [pk_col("id", "integer")];
+        let r: HashMap<String, JsonValue> = HashMap::new();
+        assert_eq!(build_search_result_where("postgres", &cols, &r), None);
+    }
+
+    #[test]
+    fn test_result_where_null_pk() {
+        let cols = [pk_col("id", "integer")];
+        let r = row(&[("id", JsonValue::Null)]);
+        let result = build_search_result_where("postgres", &cols, &r).unwrap();
+        assert_eq!(result, "\"id\" IS NULL");
+    }
+
+    #[test]
+    fn test_result_where_special_chars() {
+        let cols = [pk_col("name", "varchar")];
+        let r = row(&[("name", json!("o'neil"))]);
+        let result = build_search_result_where("postgres", &cols, &r).unwrap();
+        assert_eq!(result, "\"name\" = 'o''neil'");
+    }
+
+    #[test]
+    fn test_result_where_mysql_quoting() {
+        let cols = [pk_col("id", "integer")];
+        let r = row(&[("id", json!(1))]);
+        let result = build_search_result_where("mysql", &cols, &r).unwrap();
+        assert_eq!(result, "`id` = 1");
+    }
+
+    #[test]
+    fn test_result_where_sqlserver_quoting() {
+        let cols = [pk_col("id", "integer")];
+        let r = row(&[("id", json!(1))]);
+        let result = build_search_result_where("sqlserver", &cols, &r).unwrap();
+        assert_eq!(result, "[id] = 1");
+    }
+
+    #[test]
+    fn test_result_where_skipped_cols_not_included() {
+        let cols = [
+            pk_col("id", "integer"),
+            col("data", "geometry"), // should be skipped
+        ];
+        let r = row(&[("id", json!(1)), ("data", json!("POINT(0 0)"))]);
+        let result = build_search_result_where("postgres", &cols, &r).unwrap();
+        // "data" is SKIP type but it's not a PK so it won't be included anyway
+        // (PKs are preferred). This test verifies that SKIP columns aren't
+        // included in the fallback path either.
+        assert_eq!(result, "\"id\" = 1");
+    }
+
+    #[test]
+    fn test_result_where_all_searchable_no_pk() {
+        let cols = [col("a", "text"), col("b", "text")];
+        let r = row(&[("a", json!("x")), ("b", json!("y"))]);
+        let result = build_search_result_where("postgres", &cols, &r).unwrap();
+        assert!(result.contains("\"a\" = 'x'"));
+        assert!(result.contains("\"b\" = 'y'"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -208,6 +208,7 @@ pub fn run() {
             commands::get_table_count,
             commands::update_table_row,
             commands::delete_table_row,
+            commands::build_table_search_filter,
             // File operations commands
             commands::save_query_file,
             commands::load_query_file,

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core'
 import { save as showSaveDialog } from '@tauri-apps/plugin-dialog'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   AlertDialog,
@@ -31,6 +31,7 @@ import {
 import { Spinner } from '@/components/ui/spinner'
 import { useMinLoadingTime } from '@/composables/useMinLoadingTime'
 import { toast } from '@/composables/useNotifications'
+import { useTableSearch } from '@/composables/useTableSearch'
 import { ConnectionStatus, useConnectionStore } from '@/store'
 import {
   computeOffset,
@@ -73,6 +74,22 @@ const filterInput = ref('')
 const appliedFilter = ref('')
 const hiddenColumns = ref<Set<string>>(new Set())
 const showColumnMenu = ref(false)
+
+// ── Search state ──
+const searchTerm = ref('')
+const searchInputRef = ref<HTMLInputElement | null>(null)
+let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
+const searchFilter = ref<string | null>(null) // active WHERE clause from search
+const { isSearching, invokeSearch, cancelPending } = useTableSearch()
+
+// Tracks whether the search input was just blurred by an ESC press,
+// so the next ESC (anywhere) triggers a full clear.
+let escBlurredSearch = false
+
+// Watch searchTerm to trigger debounced search on every keystroke
+watch(searchTerm, () => {
+  onSearchInput()
+})
 
 const data = ref<TableDataResult | null>(null)
 const totalCount = ref(0)
@@ -285,7 +302,7 @@ async function fetchColumnInfo() {
 }
 
 function applyFilter() {
-  appliedFilter.value = filterInput.value.trim()
+  resolveAppliedFilter()
   currentPage.value = 1
   refresh()
 }
@@ -296,6 +313,102 @@ function clearFilter() {
     appliedFilter.value = ''
     currentPage.value = 1
     refresh()
+  }
+}
+
+// ── Search handlers ──
+
+/** Called whenever `searchTerm` changes — debounces 300ms then invokes backend. */
+function onSearchInput() {
+  if (searchDebounceTimer)
+    clearTimeout(searchDebounceTimer)
+
+  const term = searchTerm.value.trim()
+  if (!term) {
+    cancelPending()
+    searchFilter.value = null
+    resolveAppliedFilter()
+    currentPage.value = 1
+    refresh()
+    return
+  }
+
+  searchDebounceTimer = setTimeout(async () => {
+    const filter = await invokeSearch(
+      props.connectionId,
+      props.database,
+      props.schema,
+      props.tableName,
+      searchTerm.value,
+    )
+
+    if (filter !== null) {
+      searchFilter.value = filter || null
+      resolveAppliedFilter()
+      currentPage.value = 1
+      refresh()
+    }
+  }, 300)
+}
+
+/**
+ * Resolve `appliedFilter` from search and/or manual filter.
+ *
+ * Priority: search filter overrides manual filter when search is active.
+ */
+function resolveAppliedFilter() {
+  if (searchTerm.value.trim() && searchFilter.value) {
+    // Combine: search AND manual filter (or just search if no manual filter)
+    const manual = filterInput.value.trim()
+    if (manual)
+      appliedFilter.value = `${searchFilter.value} AND (${manual})`
+    else
+      appliedFilter.value = searchFilter.value
+  }
+  else {
+    // No search active — use manual filter only
+    appliedFilter.value = filterInput.value.trim() || ''
+  }
+}
+
+function clearSearch() {
+  searchTerm.value = ''
+  cancelPending()
+  if (searchDebounceTimer) {
+    clearTimeout(searchDebounceTimer)
+    searchDebounceTimer = null
+  }
+  searchFilter.value = null
+  resolveAppliedFilter()
+  currentPage.value = 1
+  refresh()
+}
+
+function onSearchKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    if (searchTerm.value) {
+      // First ESC with search active: blur input, mark for second-ESC clear
+      escBlurredSearch = true
+      searchInputRef.value?.blur()
+    }
+    else {
+      // No search text: just blur
+      searchInputRef.value?.blur()
+    }
+    e.preventDefault()
+  }
+}
+
+function onSearchFocus() {
+  escBlurredSearch = false
+}
+
+/** Handle ESC key on window — catches the "second ESC" after search input is blurred. */
+function onGlobalKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && escBlurredSearch) {
+    escBlurredSearch = false
+    clearSearch()
+    e.preventDefault()
   }
 }
 
@@ -579,11 +692,16 @@ const formatValue = formatTableValue
 const isNullValue = isTableNullValue
 
 onMounted(async () => {
+  document.addEventListener('keydown', onGlobalKeydown)
   const connected = await ensureConnection()
   if (connected) {
     fetchColumnInfo()
     refresh()
   }
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onGlobalKeydown)
 })
 
 watch(
@@ -592,6 +710,13 @@ watch(
     currentPage.value = 1
     appliedFilter.value = ''
     filterInput.value = ''
+    searchTerm.value = ''
+    searchFilter.value = null
+    cancelPending()
+    if (searchDebounceTimer) {
+      clearTimeout(searchDebounceTimer)
+      searchDebounceTimer = null
+    }
     hiddenColumns.value = new Set()
     connectionError.value = null
 
@@ -617,6 +742,63 @@ watch(
   <div class="data-table-view flex flex-col h-full" @click="showColumnMenu = false">
     <!-- Filter / Toolbar bar -->
     <div class="px-3 py-1.5 border-b bg-muted/20 flex gap-1.5 items-center">
+      <!-- 🔍 Search icon -->
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="text-muted-foreground flex-shrink-0"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+      </svg>
+
+      <!-- Search input — searches across all columns -->
+      <div class="flex-1 min-w-0 relative">
+        <Input
+          ref="searchInputRef"
+          v-model="searchTerm"
+          :placeholder="t('components.dataTableView.searchPlaceholder')"
+          class="text-xs pr-7 flex-1 h-7"
+          @keydown="onSearchKeydown"
+          @focus="onSearchFocus"
+        />
+        <!-- Inline spinner when search is active and waiting for backend -->
+        <div
+          v-if="isSearching"
+          class="text-muted-foreground right-2 top-1/2 absolute -translate-y-1/2"
+        >
+          <svg class="h-3.5 w-3.5 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+        </div>
+      </div>
+
+      <!-- Clear search button -->
+      <Button
+        v-if="searchTerm"
+        variant="ghost"
+        size="icon"
+        class="flex-shrink-0 h-7 w-7"
+        :title="t('components.dataTableView.clearSearch')"
+        @click.stop="clearSearch"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </Button>
+
+      <!-- Visual separator between search and filter sections -->
+      <div class="mx-0.5 bg-border flex-shrink-0 h-5 w-px" />
+
       <!-- Filter icon -->
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/composables/useTableSearch.ts
+++ b/src/composables/useTableSearch.ts
@@ -1,0 +1,73 @@
+import { invoke } from '@tauri-apps/api/core'
+import { ref } from 'vue'
+
+/**
+ * Composable for inline row data search across all columns.
+ *
+ * Provides async invocation of the `build_table_search_filter` backend command
+ * with a run-ID cancellation pattern to discard stale responses from
+ * previous searches.
+ *
+ * The caller is responsible for debouncing (e.g. 300ms `setTimeout`) and for
+ * wiring the returned WHERE clause into the data fetch pipeline.
+ */
+export function useTableSearch() {
+  const isSearching = ref(false)
+  let currentRunId = 0
+
+  /**
+   * Call the backend to build a search WHERE clause.
+   * Returns `null` if the term is empty, no searchable columns exist, or
+   * the response was superseded by a newer search.
+   */
+  async function invokeSearch(
+    connectionId: string,
+    database: string,
+    schema: string | undefined,
+    tableName: string,
+    searchTerm: string,
+  ): Promise<string | null> {
+    const term = searchTerm.trim()
+    if (!term)
+      return null
+
+    const runId = ++currentRunId
+    isSearching.value = true
+
+    try {
+      const filter = await invoke<string>('build_table_search_filter', {
+        connectionId,
+        database,
+        schema: schema ?? null,
+        tableName,
+        searchTerm: term,
+      })
+      // Discard stale response from a previous search
+      if (runId !== currentRunId)
+        return null
+
+      return filter || null
+    }
+    catch {
+      if (runId !== currentRunId)
+        return null
+      return null
+    }
+    finally {
+      if (runId === currentRunId)
+        isSearching.value = false
+    }
+  }
+
+  /** Cancel any in-flight search by incrementing the run ID. */
+  function cancelPending() {
+    currentRunId++
+    isSearching.value = false
+  }
+
+  return {
+    isSearching,
+    invokeSearch,
+    cancelPending,
+  }
+}

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -748,6 +748,8 @@ export const enUS = {
       noResults: 'Execute a query to see results',
     },
     dataTableView: {
+      searchPlaceholder: 'Search all columns...',
+      clearSearch: 'Clear search',
       filterPlaceholder: 'Filter (SQL WHERE clause, e.g. age > 18 AND status = \'active\')',
       clearFilter: 'Clear filter',
       refresh: 'Refresh',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -731,6 +731,8 @@ export const zhCN = {
       noResults: '执行查询以查看结果',
     },
     dataTableView: {
+      searchPlaceholder: '搜索所有列...',
+      clearSearch: '清除搜索',
       filterPlaceholder: '过滤（SQL WHERE 子句，例如 age > 18 AND status = \'active\'）',
       clearFilter: '清除过滤',
       refresh: '刷新',


### PR DESCRIPTION
## Summary

Adds an inline search input to the data table view toolbar that searches across all text and numeric columns. Users can now find rows without writing SQL.

## Changes

### Backend (Rust)
- **New** `src-tauri/src/database/search.rs`: Search SQL generation module with:
  - `classify_column()` — classifies column types as Text/Numeric/Skip
  - `build_table_search_where()` — builds dialect-aware WHERE clause with `LOWER(CAST(col AS TYPE)) LIKE '%term%'` for text, exact match + LIKE for numeric
  - `build_search_result_where()` — generates stable row-identifying WHERE using PKs (for future navigation)
  - Supports PostgreSQL, MySQL, SQL Server, SQLite, DuckDB, ClickHouse, JDBC, Trino
  - 38 unit tests covering all dialects + edge cases
- **Modified** `database/mod.rs`: Register search module
- **Modified** `commands/browse.rs`: Add `build_table_search_filter` Tauri command
- **Modified** `lib.rs`: Register new command

### Frontend (Vue/TypeScript)
- **New** `src/composables/useTableSearch.ts`: Composable with run-ID cancellation pattern
- **Modified** `DataTableView.vue`: Search input in toolbar with magnifying glass icon, 300ms debounce, two-stage ESC (blur → clear), combined search + filter support
- **Modified** `enUS.ts` / `zhCN.ts`: i18n keys for search

## Architecture

The backend generates a search WHERE clause (`(LOWER(CAST(col1 AS TEXT)) LIKE '%term%' OR col2 = 42 OR ...)`). The frontend injects it as the `filter` parameter into the existing `get_table_data`/ `get_table_count` pipeline, reusing all existing pagination, sorting, and error handling.

## Testing
- ✅ 167 Rust unit tests pass (38 new)
- ✅ 302 frontend tests pass
- ✅ Clean frontend build (vue-tsc + vite)
- ✅ 0 lint errors

## Related Issue

Closes #66