### PR TITLE
feat: visual query execution plan as structured tree with cost highlighting

### DIFF
--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -7,23 +7,58 @@ use crate::api_response::{db_error_to_api_error, ApiResponse};
 #[cfg(feature = "firebird")]
 use crate::database::FirebirdAdapter;
 use crate::database::{
-    ClickHouseAdapter, ConnectionConfig, DatabaseAdapter, DuckDbAdapter, HttpSqlAdapter,
-    JdbcBridgeAdapter, MySQLAdapter, PostgresAdapter, QueryResult, RqliteAdapter, SqlServerAdapter,
-    TursoAdapter,
+    ClickHouseAdapter, ConnectionConfig, DatabaseAdapter, DuckDbAdapter, ExplainResult,
+    HttpSqlAdapter, JdbcBridgeAdapter, MySQLAdapter, PostgresAdapter, QueryResult, RqliteAdapter,
+    SqlServerAdapter, TursoAdapter,
 };
 use crate::state::{ActiveConnection, AppState};
-use serde::{Deserialize, Serialize};
 use tauri::State;
 
-/// Query execution plan details.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueryPlan {
-    /// Database-specific query plan representation.
-    pub plan: String,
-    /// Estimated cost (if available).
-    pub estimated_cost: Option<f64>,
-    /// Additional plan details.
-    pub details: Option<String>,
+/// Extract raw plan text from a QueryResult.
+/// For JSON format (single row, single column), extracts the JSON string cleanly.
+/// For text format, concatenates all rows with newlines, joining multi-column
+/// rows with ` | ` (the frontend parsers handle this for each database).
+fn extract_plan_text(result: &QueryResult) -> String {
+    use crate::database::QueryValue;
+    result
+        .rows
+        .iter()
+        .map(|row| {
+            row.values()
+                .map(|v| match v {
+                    QueryValue::String(s) => s.clone(),
+                    other => format!("{:?}", other),
+                })
+                .collect::<Vec<_>>()
+                .join(" | ")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Extract plan text from a QueryResult using the StmtText column.
+/// SQL Server SHOWPLAN_TEXT returns a single "StmtText" column.
+/// SQL Server STATISTICS PROFILE returns multiple columns including
+/// "StmtText" (plan tree text), "Rows", "PhysicalOp", etc.
+/// This function extracts only the "StmtText" column to avoid
+/// interleaving metadata into the plan text.
+fn extract_plan_text_for_sqlserver(result: &QueryResult) -> String {
+    use crate::database::QueryValue;
+    let has_stmt_col = result.columns.iter().any(|c| c == "StmtText");
+    if !has_stmt_col {
+        // Fall back to generic extraction if column not found
+        return extract_plan_text(result);
+    }
+    result
+        .rows
+        .iter()
+        .map(|row| match row.get("StmtText") {
+            Some(QueryValue::String(s)) => s.clone(),
+            Some(other) => format!("{:?}", other),
+            None => String::new(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Connect a temporary adapter, execute a query, then disconnect.
@@ -346,18 +381,17 @@ pub async fn cancel_query(_query_id: String, _state: State<'_, AppState>) -> Res
 pub async fn explain_query(
     connection_id: String,
     sql: String,
+    analyze: Option<bool>,
     state: State<'_, AppState>,
-) -> Result<QueryPlan, String> {
-    // Basic SQL validation to prevent obvious injection attacks
+) -> Result<ExplainResult, String> {
     let sql_lower = sql.trim().to_lowercase();
 
-    // Check for dangerous patterns
     if sql_lower.contains(";") && !sql_lower.ends_with(";") {
         return Err("Multiple statements are not allowed in EXPLAIN queries".to_string());
     }
 
-    // Remove trailing semicolon for consistent processing
     let sql = sql.trim().trim_end_matches(';');
+    let analyze = analyze.unwrap_or(false);
 
     let connections = state.connections.lock().await;
 
@@ -365,86 +399,117 @@ pub async fn explain_query(
         .get(&connection_id)
         .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?;
 
-    // Execute explain query based on connection type
-    let result = match connection {
+    let database_type = match connection {
+        ActiveConnection::Postgres(_) => "postgresql",
+        ActiveConnection::MySQL(_) => "mysql",
+        ActiveConnection::SQLite(_) => "sqlite",
+        ActiveConnection::SQLServer(_) => "sqlserver",
+        ActiveConnection::DuckDb(_) => "duckdb",
+        ActiveConnection::ClickHouse(_) => "clickhouse",
+        #[cfg(feature = "firebird")]
+        ActiveConnection::Firebird(_) => "firebird",
+        ActiveConnection::JdbcBridge(_) => "generic",
+        ActiveConnection::HttpSql(_) => "generic",
+        ActiveConnection::Rqlite(_) => "rqlite",
+        ActiveConnection::Turso(_) => "turso",
+    };
+
+    let (result, plan_format) = match connection {
         ActiveConnection::Postgres(adapter) => {
             let adapter = adapter.lock().await;
-            let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            let explain_sql = if analyze {
+                format!("EXPLAIN (ANALYZE, FORMAT JSON) {}", sql)
+            } else {
+                format!("EXPLAIN (FORMAT JSON) {}", sql)
+            };
+            (adapter.execute_query(&explain_sql).await, "json")
         }
         ActiveConnection::MySQL(adapter) => {
             let adapter = adapter.lock().await;
-            let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            if analyze {
+                // MySQL EXPLAIN ANALYZE returns TREE text, not JSON
+                (adapter.execute_query(&format!("EXPLAIN ANALYZE {}", sql)).await, "text")
+            } else {
+                (adapter.execute_query(&format!("EXPLAIN FORMAT=JSON {}", sql)).await, "json")
+            }
         }
         ActiveConnection::SQLServer(adapter) => {
             let adapter = adapter.lock().await;
-            // SQL Server uses SET SHOWPLAN_TEXT ON
-            let showplan_sql = format!("SET SHOWPLAN_TEXT ON; {}", sql);
-            adapter.execute_query(&showplan_sql).await
+            let settings = if analyze {
+                "SET STATISTICS PROFILE ON"
+            } else {
+                "SET SHOWPLAN_TEXT ON"
+            };
+            let cleanup = if analyze {
+                "SET STATISTICS PROFILE OFF"
+            } else {
+                "SET SHOWPLAN_TEXT OFF"
+            };
+            let explain_sql = format!("{}; {}; {}", settings, sql, cleanup);
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         ActiveConnection::SQLite(adapter) => {
             let adapter = adapter.lock().await;
-            // SQLite uses EXPLAIN QUERY PLAN
             let explain_sql = format!("EXPLAIN QUERY PLAN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         ActiveConnection::DuckDb(adapter) => {
             let adapter = adapter.lock().await;
-            let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            let explain_sql = if analyze {
+                format!("EXPLAIN ANALYZE {}", sql)
+            } else {
+                format!("EXPLAIN {}", sql)
+            };
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         ActiveConnection::ClickHouse(adapter) => {
             let adapter = adapter.lock().await;
             let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         #[cfg(feature = "firebird")]
         ActiveConnection::Firebird(adapter) => {
             let adapter = adapter.lock().await;
             let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         ActiveConnection::JdbcBridge(adapter) => {
             let adapter = adapter.lock().await;
             let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         ActiveConnection::HttpSql(adapter) => {
             let adapter = adapter.lock().await;
             let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         ActiveConnection::Rqlite(adapter) => {
             let adapter = adapter.lock().await;
             let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            (adapter.execute_query(&explain_sql).await, "text")
         }
         ActiveConnection::Turso(adapter) => {
             let adapter = adapter.lock().await;
             let explain_sql = format!("EXPLAIN {}", sql);
-            adapter.execute_query(&explain_sql).await
+            (adapter.execute_query(&explain_sql).await, "text")
         }
-    }
-    .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+    };
+    let result = result.map_err(|e| format!("EXPLAIN query failed: {}", e))?;
 
-    // Convert result to QueryPlan
-    let plan = result
-        .rows
-        .iter()
-        .map(|row| {
-            row.values()
-                .map(|v| format!("{:?}", v))
-                .collect::<Vec<_>>()
-                .join(" | ")
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    // SQL Server SHOWPLAN_TEXT returns a single "StmtText" column.
+    // STATISTICS PROFILE returns multiple columns — use StmtText-specific
+    // extraction to avoid interleaving metadata into the plan text.
+    let raw = if database_type == "sqlserver" {
+        extract_plan_text_for_sqlserver(&result)
+    } else {
+        extract_plan_text(&result)
+    };
 
-    Ok(QueryPlan {
-        plan,
-        estimated_cost: None,
-        details: Some(format!("{} rows in plan", result.rows.len())),
+    Ok(ExplainResult {
+        database_type: database_type.to_string(),
+        raw,
+        format: plan_format.to_string(),
+        analyze,
     })
 }
 
@@ -455,19 +520,6 @@ pub async fn explain_query(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_query_plan_structure() {
-        let plan = QueryPlan {
-            plan: "Seq Scan on users".to_string(),
-            estimated_cost: Some(1.0),
-            details: Some("1 row".to_string()),
-        };
-
-        assert_eq!(plan.plan, "Seq Scan on users");
-        assert_eq!(plan.estimated_cost, Some(1.0));
-        assert!(plan.details.is_some());
-    }
 
     #[test]
     fn test_sql_validation() {

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -366,6 +366,9 @@ pub async fn cancel_query(_query_id: String, _state: State<'_, AppState>) -> Res
 ///
 /// * `connection_id` - ID of the active connection
 /// * `sql` - SQL query to analyze
+/// * `analyze` - Whether to run EXPLAIN ANALYZE for actual runtime stats
+/// * `database` - Optional target database (creates a temporary connection if
+///   different from the active connection's database)
 /// * `state` - Application state
 ///
 /// # Returns
@@ -382,6 +385,7 @@ pub async fn explain_query(
     connection_id: String,
     sql: String,
     analyze: Option<bool>,
+    database: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ExplainResult, String> {
     let sql_lower = sql.trim().to_lowercase();
@@ -393,6 +397,367 @@ pub async fn explain_query(
     let sql = sql.trim().trim_end_matches(';');
     let analyze = analyze.unwrap_or(false);
 
+    // If a target database is specified we may need a temporary adapter.
+    // We hold the connections lock only long enough to clone the config, then
+    // release it before doing any network I/O.
+    if let Some(ref db) = database {
+        enum TempExplainKind {
+            Postgres(ConnectionConfig),
+            MySQL(ConnectionConfig),
+            SQLServer(ConnectionConfig),
+            DuckDb(ConnectionConfig),
+            ClickHouse(ConnectionConfig),
+            JdbcBridge(ConnectionConfig),
+            HttpSql(ConnectionConfig),
+            #[cfg(feature = "firebird")]
+            Firebird(ConnectionConfig),
+            Rqlite(ConnectionConfig),
+            Turso(ConnectionConfig),
+        }
+
+        let temp_kind: Option<TempExplainKind> = {
+            let connections = state.connections.lock().await;
+            let connection = connections
+                .get(&connection_id)
+                .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?;
+
+            match connection {
+                ActiveConnection::Postgres(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::Postgres(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::MySQL(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::MySQL(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::SQLServer(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::SQLServer(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::SQLite(_) => None,
+                ActiveConnection::DuckDb(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::DuckDb(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::ClickHouse(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::ClickHouse(cfg))
+                    } else {
+                        None
+                    }
+                }
+                #[cfg(feature = "firebird")]
+                ActiveConnection::Firebird(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::Firebird(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::JdbcBridge(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::JdbcBridge(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::HttpSql(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::HttpSql(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::Rqlite(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::Rqlite(cfg))
+                    } else {
+                        None
+                    }
+                }
+                ActiveConnection::Turso(adapter) => {
+                    let adapter = adapter.lock().await;
+                    if Some(db.as_str()) != adapter.config.database.as_deref() {
+                        let mut cfg = adapter.config.clone();
+                        cfg.database = Some(db.clone());
+                        Some(TempExplainKind::Turso(cfg))
+                    } else {
+                        None
+                    }
+                }
+            }
+            // connections lock is dropped here, before any network I/O
+        };
+
+        if let Some(kind) = temp_kind {
+            return match kind {
+                TempExplainKind::Postgres(cfg) => {
+                    let database_type = "postgresql";
+                    let mut temp = PostgresAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = if analyze {
+                        format!("EXPLAIN (ANALYZE, FORMAT JSON) {}", sql)
+                    } else {
+                        format!("EXPLAIN (FORMAT JSON) {}", sql)
+                    };
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "json".to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::MySQL(cfg) => {
+                    let database_type = "mysql";
+                    let mut temp = MySQLAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let (explain_sql, plan_format) = if analyze {
+                        (format!("EXPLAIN ANALYZE {}", sql), "text")
+                    } else {
+                        (format!("EXPLAIN FORMAT=JSON {}", sql), "json")
+                    };
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: plan_format.to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::SQLServer(cfg) => {
+                    let database_type = "sqlserver";
+                    let mut temp = SqlServerAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let settings = if analyze {
+                        "SET STATISTICS PROFILE ON"
+                    } else {
+                        "SET SHOWPLAN_TEXT ON"
+                    };
+                    let cleanup = if analyze {
+                        "SET STATISTICS PROFILE OFF"
+                    } else {
+                        "SET SHOWPLAN_TEXT OFF"
+                    };
+                    let explain_sql = format!("{}; {}; {}", settings, sql, cleanup);
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text_for_sqlserver(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::DuckDb(cfg) => {
+                    let database_type = "duckdb";
+                    let mut temp = DuckDbAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = if analyze {
+                        format!("EXPLAIN ANALYZE {}", sql)
+                    } else {
+                        format!("EXPLAIN {}", sql)
+                    };
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::ClickHouse(cfg) => {
+                    let database_type = "clickhouse";
+                    let mut temp = ClickHouseAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = format!("EXPLAIN {}", sql);
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+                #[cfg(feature = "firebird")]
+                TempExplainKind::Firebird(cfg) => {
+                    let database_type = "firebird";
+                    let mut temp = FirebirdAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = format!("EXPLAIN {}", sql);
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::JdbcBridge(cfg) => {
+                    let database_type = "generic";
+                    let mut temp = JdbcBridgeAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = format!("EXPLAIN {}", sql);
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::HttpSql(cfg) => {
+                    let database_type = "generic";
+                    let mut temp = HttpSqlAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = format!("EXPLAIN {}", sql);
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::Rqlite(cfg) => {
+                    let database_type = "rqlite";
+                    let mut temp = RqliteAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = format!("EXPLAIN {}", sql);
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+                TempExplainKind::Turso(cfg) => {
+                    let database_type = "turso";
+                    let mut temp = TursoAdapter::new(cfg);
+                    temp.connect().await.map_err(|e| {
+                        format!("Failed to connect to database for EXPLAIN: {}", e)
+                    })?;
+                    let explain_sql = format!("EXPLAIN {}", sql);
+                    let result = temp
+                        .execute_query(&explain_sql)
+                        .await
+                        .map_err(|e| format!("EXPLAIN query failed: {}", e))?;
+                    let raw = extract_plan_text(&result);
+                    let _ = temp.disconnect().await;
+                    Ok(ExplainResult {
+                        database_type: database_type.to_string(),
+                        raw,
+                        format: "text".to_string(),
+                        analyze,
+                    })
+                }
+            };
+        }
+    }
+
+    // Common path: use the already-connected adapter
     let connections = state.connections.lock().await;
 
     let connection = connections

--- a/src-tauri/src/database/explain.rs
+++ b/src-tauri/src/database/explain.rs
@@ -1,0 +1,19 @@
+//! Query execution plan types.
+//!
+//! This module defines the structures returned by the `explain_query` command
+//! for visual query execution plan display.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of an EXPLAIN query execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExplainResult {
+    /// Database type (e.g., "postgresql", "mysql", "sqlite", "sqlserver").
+    pub database_type: String,
+    /// Raw EXPLAIN output text or JSON string.
+    pub raw: String,
+    /// Format of the raw output: "json" or "text".
+    pub format: String,
+    /// Whether EXPLAIN ANALYZE was used.
+    pub analyze: bool,
+}

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -64,6 +64,7 @@ pub mod clickhouse;
 pub mod config;
 pub mod duckdb;
 pub mod error;
+pub mod explain;
 #[cfg(feature = "firebird")]
 pub mod firebird;
 pub mod http_sql;
@@ -91,6 +92,7 @@ pub use clickhouse::{ClickHouseAdapter, ClickHousePool};
 pub use config::{ConnectionConfig, DatabaseType, PoolConfig, SslMode};
 pub use duckdb::{DuckDbAdapter, DuckDbPool};
 pub use error::{DbError, DbResult};
+pub use explain::ExplainResult;
 #[cfg(feature = "firebird")]
 pub use firebird::{FirebirdAdapter, FirebirdPool};
 pub use http_sql::{HttpSqlAdapter, HttpSqlPool};

--- a/src/components/database-browser/QueryResultPanel.vue
+++ b/src/components/database-browser/QueryResultPanel.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { QueryResult } from '@/store/tabStore'
 import type { ApiError } from '@/types/api'
+import type { ExplainResult } from '@/types/explainPlan'
 import type { ColumnFilter, SortColumn } from '@/types/grid'
 import { invoke } from '@tauri-apps/api/core'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ExplainPlanPanel } from '@/components/explain-plan'
 import DataGrid from '@/components/grid/DataGrid.vue'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
@@ -21,6 +23,9 @@ type Props = {
   connectionId?: string
   database?: string
   schema?: string
+  explainPlan?: ExplainResult | null
+  isExplaining?: boolean
+  explainError?: string | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -34,6 +39,9 @@ const props = withDefaults(defineProps<Props>(), {
   connectionId: undefined,
   database: undefined,
   schema: undefined,
+  explainPlan: null,
+  isExplaining: false,
+  explainError: null,
 })
 
 const emit = defineEmits<{
@@ -41,6 +49,18 @@ const emit = defineEmits<{
   (e: 'resize', height: number): void
   (e: 'refresh'): void
 }>()
+
+const activeOutputView = ref<'results' | 'explain'>('results')
+
+watch(() => props.explainPlan, (plan) => {
+  if (plan)
+    activeOutputView.value = 'explain'
+})
+
+watch(() => props.results, (res) => {
+  if (res && !props.explainPlan)
+    activeOutputView.value = 'results'
+})
 
 const { t } = useI18n()
 
@@ -218,120 +238,131 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
       @mousedown="startResize"
     />
 
-    <!-- Header -->
-    <div class="px-3 py-1.5 border-b bg-muted/30 flex flex-shrink-0 items-center justify-between">
-      <div class="flex gap-4 items-center">
-        <span class="text-sm font-medium">
-          {{ t('components.queryResult.title') }}
-        </span>
-        <div v-if="displayResults" class="text-xs text-muted-foreground flex gap-2 items-center">
-          <span v-if="displayResults.columns.length > 0">{{ t('components.queryResult.rows', { count: displayResults.rowCount }) }}</span>
-          <span v-else-if="displayResults.rowsAffected !== undefined">{{ t('components.queryResult.rowsAffected', { count: displayResults.rowsAffected }) }}</span>
-          <span v-if="formattedTime">• {{ t('components.queryResult.time', { time: formattedTime }) }}</span>
-        </div>
+    <!-- Tab bar (Results | Explain) -->
+    <div class="flex h-9 shrink-0 items-center gap-1 border-b bg-muted/20 px-3 text-xs">
+      <Button
+        size="sm"
+        variant="ghost"
+        class="h-6 px-2 text-xs"
+        :class="activeOutputView === 'results' ? 'bg-accent text-accent-foreground' : ''"
+        :disabled="!displayResults && !displayExecuting"
+        @click="activeOutputView = 'results'"
+      >
+        {{ t('pages.queries.explain.tabLabels.results') }}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        class="h-6 px-2 text-xs"
+        :class="activeOutputView === 'explain' ? 'bg-accent text-accent-foreground' : ''"
+        :disabled="!explainPlan && !isExplaining && !explainError"
+        @click="activeOutputView = 'explain'"
+      >
+        {{ t('pages.queries.explain.tabLabels.explain') }}
+      </Button>
+      <div class="flex-1" />
+      <div v-if="displayResults && activeOutputView === 'results'" class="text-xs text-muted-foreground flex gap-2 items-center">
+        <span v-if="displayResults.columns.length > 0">{{ t('components.queryResult.rows', { count: displayResults.rowCount }) }}</span>
+        <span v-else-if="displayResults.rowsAffected !== undefined">{{ t('components.queryResult.rowsAffected', { count: displayResults.rowsAffected }) }}</span>
+        <span v-if="formattedTime">• {{ t('components.queryResult.time', { time: formattedTime }) }}</span>
       </div>
-      <div class="flex gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          class="h-6 w-6"
-          :title="t('components.dataTableView.refresh')"
-          @click="handleRefresh"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
-            <path d="M21 3v5h-5" />
-            <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
-            <path d="M8 16H3v5" />
-          </svg>
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          class="h-6 w-6"
-          :title="t('components.queryResult.close')"
-          @click="close"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M18 6 6 18" />
-            <path d="m6 6 12 12" />
-          </svg>
-        </Button>
-      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        class="h-6 w-6"
+        :title="t('components.queryResult.close')"
+        @click="close"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </Button>
     </div>
 
     <!-- Content -->
     <div class="flex-1 min-h-0">
-      <!-- Loading state -->
-      <div v-if="displayExecuting && !displayResults" class="flex h-full items-center justify-center">
-        <div class="text-center">
-          <Spinner class="mx-auto mb-2 h-8 w-8" />
-          <p class="text-sm text-muted-foreground">
-            {{ t('components.queryResult.executing') }}
-          </p>
+      <!-- Results view -->
+      <template v-if="activeOutputView === 'results'">
+        <!-- Loading state -->
+        <div v-if="displayExecuting && !displayResults" class="flex h-full items-center justify-center">
+          <div class="text-center">
+            <Spinner class="mx-auto mb-2 h-8 w-8" />
+            <p class="text-sm text-muted-foreground">
+              {{ t('components.queryResult.executing') }}
+            </p>
+          </div>
         </div>
-      </div>
 
-      <!-- Error state -->
-      <div v-else-if="displayError && !displayResults" class="p-4">
-        <div class="p-4 border border-destructive/30 rounded-md bg-destructive/5">
-          <div class="flex gap-3 items-start">
-            <span class="i-carbon-warning-alt text-destructive mt-0.5 flex-shrink-0 h-5 w-5" />
-            <div>
-              <p
-                v-for="(line, index) in (typeof displayError === 'string' ? displayError : formatApiError(displayError, t)).split('\n\n')"
-                :key="index"
-                class="text-sm text-destructive"
-              >
-                {{ line }}
-              </p>
+        <!-- Error state -->
+        <div v-else-if="displayError && !displayResults" class="p-4">
+          <div class="p-4 border border-destructive/30 rounded-md bg-destructive/5">
+            <div class="flex gap-3 items-start">
+              <span class="i-carbon-warning-alt text-destructive mt-0.5 flex-shrink-0 h-5 w-5" />
+              <div>
+                <p
+                  v-for="(line, index) in (typeof displayError === 'string' ? displayError : formatApiError(displayError, t)).split('\n\n')"
+                  :key="index"
+                  class="text-sm text-destructive"
+                >
+                  {{ line }}
+                </p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- DataGrid (SELECT results with columns) -->
-      <DataGrid
-        v-else-if="displayResults && displayResults.columns.length > 0"
-        :columns="displayResults.columns"
-        :rows="displayResults.rows"
-        :row-count="displayResults.rowCount"
-        :execution-time-ms="displayExecutionTime"
-        :connection-id="connectionId"
-        :database="database"
-        :schema="schema"
-        :loading="displayExecuting"
-        :error="displayError ? String(displayError) : null"
-        @sort-change="handleSortChange"
-        @filter-change="handleFilterChange"
-        @refresh="handleRefresh"
+        <!-- DataGrid (SELECT results with columns) -->
+        <DataGrid
+          v-else-if="displayResults && displayResults.columns.length > 0"
+          :columns="displayResults.columns"
+          :rows="displayResults.rows"
+          :row-count="displayResults.rowCount"
+          :execution-time-ms="displayExecutionTime"
+          :connection-id="connectionId"
+          :database="database"
+          :schema="schema"
+          :loading="displayExecuting"
+          :error="displayError ? String(displayError) : null"
+          @sort-change="handleSortChange"
+          @filter-change="handleFilterChange"
+          @refresh="handleRefresh"
+        />
+
+        <!-- DML/DLL success (no columns returned) -->
+        <div v-else-if="displayResults && displayResults.columns.length === 0" class="flex h-full items-center justify-center">
+          <div class="text-muted-foreground text-center">
+            <span class="i-carbon-checkmark mx-auto mb-2 opacity-50 h-8 w-8 block" />
+            <p class="text-sm font-medium">
+              {{ t('components.queryResult.success') }}
+            </p>
+            <p v-if="displayResults.rowsAffected !== undefined" class="text-xs mt-1">
+              {{ t('components.queryResult.rowsAffected', { count: displayResults.rowsAffected }) }}
+            </p>
+            <p v-else class="text-xs mt-1">
+              {{ t('components.queryResult.commandCompleted') }}
+            </p>
+          </div>
+        </div>
+
+        <!-- No results (no query executed yet) -->
+        <div v-else class="flex h-full items-center justify-center">
+          <div class="text-muted-foreground text-center">
+            <span class="i-carbon-document-blank mx-auto mb-2 opacity-40 h-8 w-8 block" />
+            <p class="text-sm">
+              {{ t('components.queryResult.noResults') }}
+            </p>
+          </div>
+        </div>
+      </template>
+
+      <!-- Explain view -->
+      <ExplainPlanPanel
+        v-else
+        :explain-result="explainPlan"
+        :loading="isExplaining || false"
+        :error="explainError"
       />
-
-      <!-- DML/DLL success (no columns returned) -->
-      <div v-else-if="displayResults && displayResults.columns.length === 0" class="flex h-full items-center justify-center">
-        <div class="text-muted-foreground text-center">
-          <span class="i-carbon-checkmark mx-auto mb-2 opacity-50 h-8 w-8 block" />
-          <p class="text-sm font-medium">
-            {{ t('components.queryResult.success') }}
-          </p>
-          <p v-if="displayResults.rowsAffected !== undefined" class="text-xs mt-1">
-            {{ t('components.queryResult.rowsAffected', { count: displayResults.rowsAffected }) }}
-          </p>
-          <p v-else class="text-xs mt-1">
-            {{ t('components.queryResult.commandCompleted') }}
-          </p>
-        </div>
-      </div>
-
-      <!-- No results (no query executed yet) -->
-      <div v-else class="flex h-full items-center justify-center">
-        <div class="text-muted-foreground text-center">
-          <span class="i-carbon-document-blank mx-auto mb-2 opacity-40 h-8 w-8 block" />
-          <p class="text-sm">
-            {{ t('components.queryResult.noResults') }}
-          </p>
-        </div>
-      </div>
     </div>
   </div>
 </template>

--- a/src/components/database-browser/QueryResultPanel.vue
+++ b/src/components/database-browser/QueryResultPanel.vue
@@ -239,11 +239,11 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
     />
 
     <!-- Tab bar (Results | Explain) -->
-    <div class="flex h-9 shrink-0 items-center gap-1 border-b bg-muted/20 px-3 text-xs">
+    <div class="text-xs px-3 border-b bg-muted/20 flex shrink-0 gap-1 h-9 items-center">
       <Button
         size="sm"
         variant="ghost"
-        class="h-6 px-2 text-xs"
+        class="text-xs px-2 h-6"
         :class="activeOutputView === 'results' ? 'bg-accent text-accent-foreground' : ''"
         :disabled="!displayResults && !displayExecuting"
         @click="activeOutputView = 'results'"
@@ -253,7 +253,7 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
       <Button
         size="sm"
         variant="ghost"
-        class="h-6 px-2 text-xs"
+        class="text-xs px-2 h-6"
         :class="activeOutputView === 'explain' ? 'bg-accent text-accent-foreground' : ''"
         :disabled="!explainPlan && !isExplaining && !explainError"
         @click="activeOutputView = 'explain'"

--- a/src/components/explain-plan/ExplainPlanNodeTree.vue
+++ b/src/components/explain-plan/ExplainPlanNodeTree.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import type { ExplainPlanNode } from '@/types/explainPlan'
+import { computed, ref } from 'vue'
+import { getCostColor } from '@/utils/explainPlanParser'
+
+defineOptions({
+  name: 'ExplainPlanNodeTree',
+})
+
+const props = defineProps<{
+  node: ExplainPlanNode
+  totalCost?: number
+}>()
+
+const collapsed = ref(false)
+
+function toggle() {
+  if (props.node.children.length > 0)
+    collapsed.value = !collapsed.value
+}
+
+const hasActual = !!props.node.actualRows
+const rowDiffers = hasActual && props.node.rows && props.node.actualRows !== props.node.rows
+const rowRatio = rowDiffers && props.node.rows && props.node.rows > 0
+  ? Math.round((props.node.actualRows! / props.node.rows) * 100)
+  : null
+
+const costColorClass = computed(() => {
+  const cost = props.node.totalCost || 0
+  const total = props.totalCost || 0
+  const color = getCostColor(cost, total)
+  return {
+    green: 'bg-green-500',
+    yellow: 'bg-yellow-500',
+    red: 'bg-red-500',
+  }[color]
+})
+</script>
+
+<template>
+  <div>
+    <div
+      class="text-xs px-2 py-1 border rounded bg-background flex gap-1.5 cursor-pointer items-center hover:bg-muted/30"
+      :class="{ 'border-green-300 dark:border-green-700': hasActual }"
+      @click="toggle"
+    >
+      <span class="shrink-0 h-3 w-2 rounded-full" :class="costColorClass" />
+      <svg
+        v-if="node.children.length > 0 && collapsed"
+        class="text-muted-foreground shrink-0 h-3 w-3"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="m9 18 6-6-6-6" />
+      </svg>
+      <svg
+        v-else-if="node.children.length > 0"
+        class="text-muted-foreground shrink-0 h-3 w-3"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+      <span
+        v-else
+        class="shrink-0 h-3 w-3"
+      />
+      <span class="font-medium px-1 py-0.5 rounded bg-muted shrink-0">{{ node.nodeType }}</span>
+      <span
+        v-if="node.relation"
+        class="text-blue-600 shrink-0 max-w-[120px] truncate dark:text-blue-400"
+      >{{ node.relation }}</span>
+      <span
+        v-if="node.index"
+        class="text-emerald-600 shrink-0 dark:text-emerald-400"
+      >[{{ node.index }}]</span>
+      <span
+        v-if="node.cost"
+        class="text-muted-foreground shrink-0 tabular-nums"
+      >c:{{ node.cost }}</span>
+      <span
+        v-if="node.rows"
+        class="text-amber-600 shrink-0 tabular-nums dark:text-amber-400"
+      >e:{{ node.rows }}</span>
+      <span
+        v-if="hasActual"
+        class="font-semibold shrink-0 tabular-nums"
+        :class="rowDiffers ? 'text-green-600 dark:text-green-400' : 'text-muted-foreground'"
+      >
+        a:{{ node.actualRows }}<span v-if="rowDiffers && rowRatio">({{ rowRatio }}%)</span>
+      </span>
+      <span
+        v-if="node.details.length"
+        class="text-muted-foreground/40 ml-auto shrink-0 whitespace-nowrap text-ellipsis overflow-hidden"
+        :title="node.details.join('\n')"
+      >{{ node.details.join(' ') }}</span>
+    </div>
+    <div
+      v-if="node.children.length && !collapsed"
+      class="ml-5 mt-px pl-3 border-l space-y-px"
+    >
+      <ExplainPlanNodeTree
+        v-for="child in node.children"
+        :key="child.id"
+        :node="child"
+        :total-cost="totalCost"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/explain-plan/ExplainPlanNodeTree.vue
+++ b/src/components/explain-plan/ExplainPlanNodeTree.vue
@@ -44,7 +44,7 @@ const costColorClass = computed(() => {
       :class="{ 'border-green-300 dark:border-green-700': hasActual }"
       @click="toggle"
     >
-      <span class="shrink-0 h-3 w-2 rounded-full" :class="costColorClass" />
+      <span class="rounded-full shrink-0 h-3 w-2" :class="costColorClass" />
       <svg
         v-if="node.children.length > 0 && collapsed"
         class="text-muted-foreground shrink-0 h-3 w-3"

--- a/src/components/explain-plan/ExplainPlanPanel.vue
+++ b/src/components/explain-plan/ExplainPlanPanel.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import type { ExplainResult } from '@/types/explainPlan'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Spinner } from '@/components/ui/spinner'
+import ExplainPlanNodeTree from './ExplainPlanNodeTree.vue'
+import ExplainPlanRawView from './ExplainPlanRawView.vue'
+import ExplainPlanSummaryTable from './ExplainPlanSummaryTable.vue'
+
+const props = defineProps<{
+  explainResult: ExplainResult | null
+  loading: boolean
+  error: string | null
+}>()
+
+const { t } = useI18n()
+const activeView = ref<'tree' | 'summary' | 'raw'>('tree')
+
+// Use stored values from ExplainResult (computed by parseExplainResult)
+const totalCost = computed(() => props.explainResult?.totalCost)
+const mostExpensive = computed(() => props.explainResult?.mostExpensiveNode)
+
+const nodeCount = computed(() => {
+  if (!props.explainResult?.nodes.length)
+    return 0
+  function count(nodes: any[]): number {
+    let c = nodes.length
+    for (const n of nodes) {
+      c += count(n.children || [])
+    }
+    return c
+  }
+  return count(props.explainResult.nodes)
+})
+
+const formattedTotalCost = computed(() => {
+  const c = totalCost.value
+  if (c === undefined)
+    return undefined
+  return Number.isInteger(c) ? c.toFixed(0) : c.toFixed(2)
+})
+</script>
+
+<template>
+  <div class="bg-background flex flex-col h-full min-h-0">
+    <!-- Summary bar -->
+    <div
+      v-if="explainResult && !loading"
+      class="text-xs px-3 py-1.5 border-b flex shrink-0 gap-3 items-center"
+    >
+      <span class="font-medium px-2 py-0.5 border rounded bg-muted inline-flex gap-1 items-center">
+        {{ t('pages.queries.explain.title') }}
+      </span>
+      <span class="text-muted-foreground">
+        {{ explainResult.databaseType.toUpperCase() }} &middot; {{ t('pages.queries.explain.nodeCount', { count: nodeCount }) }}
+      </span>
+      <span class="flex-1" />
+      <span v-if="formattedTotalCost !== undefined" class="tabular-nums">
+        {{ t('pages.queries.explain.summary.totalCost', { cost: formattedTotalCost }) }}
+      </span>
+      <span v-if="mostExpensive" class="text-muted-foreground">
+        | {{ t('pages.queries.explain.summary.mostExpensive', { node: mostExpensive }) }}
+      </span>
+      <span v-else-if="formattedTotalCost === undefined" class="text-muted-foreground">
+        {{ t('pages.queries.explain.summary.noCostData') }}
+      </span>
+    </div>
+
+    <!-- View tabs -->
+    <div
+      v-if="explainResult && !loading"
+      class="px-3 py-1 border-b flex shrink-0 gap-1"
+    >
+      <button
+        class="text-xs font-medium px-2 py-0.5 rounded transition-colors"
+        :class="activeView === 'tree' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'"
+        @click="activeView = 'tree'"
+      >
+        {{ t('pages.queries.explain.treeView') }}
+      </button>
+      <button
+        class="text-xs font-medium px-2 py-0.5 rounded transition-colors"
+        :class="activeView === 'summary' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'"
+        @click="activeView = 'summary'"
+      >
+        {{ t('pages.queries.explain.summaryView') }}
+      </button>
+      <button
+        class="text-xs font-medium px-2 py-0.5 rounded transition-colors"
+        :class="activeView === 'raw' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'"
+        @click="activeView = 'raw'"
+      >
+        {{ t('pages.queries.explain.rawView') }}
+      </button>
+    </div>
+
+    <!-- Loading state -->
+    <div
+      v-if="loading"
+      class="flex flex-1 items-center justify-center"
+    >
+      <div class="text-center">
+        <Spinner class="mx-auto mb-2" />
+        <p class="text-sm text-muted-foreground">
+          {{ t('pages.queries.explain.running') }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Error state -->
+    <div
+      v-else-if="error"
+      class="p-4 flex flex-1 items-start justify-center"
+    >
+      <div class="text-sm text-destructive px-3 py-2 border border-destructive/30 rounded bg-destructive/5 max-w-xl">
+        <p>{{ error }}</p>
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="!explainResult"
+      class="flex flex-1 items-center justify-center"
+    >
+      <p class="text-sm text-muted-foreground">
+        {{ t('pages.queries.explain.empty') }}
+      </p>
+    </div>
+
+    <!-- Content views -->
+    <div
+      v-else
+      class="flex-1 min-h-0 overflow-auto"
+    >
+      <div
+        v-if="activeView === 'tree'"
+        class="mx-auto p-2 max-w-5xl space-y-px"
+      >
+        <ExplainPlanNodeTree
+          v-for="node in explainResult.nodes"
+          :key="node.id"
+          :node="node"
+          :total-cost="totalCost"
+        />
+      </div>
+      <ExplainPlanSummaryTable
+        v-else-if="activeView === 'summary' && explainResult"
+        :nodes="explainResult.nodes"
+      />
+      <ExplainPlanRawView
+        v-else-if="activeView === 'raw' && explainResult"
+        :raw="explainResult.raw"
+        :format="explainResult.format"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/explain-plan/ExplainPlanPanel.vue
+++ b/src/components/explain-plan/ExplainPlanPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ExplainResult } from '@/types/explainPlan'
+import type { ExplainPlanNode, ExplainResult } from '@/types/explainPlan'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Spinner } from '@/components/ui/spinner'
@@ -23,7 +23,7 @@ const mostExpensive = computed(() => props.explainResult?.mostExpensiveNode)
 const nodeCount = computed(() => {
   if (!props.explainResult?.nodes.length)
     return 0
-  function count(nodes: any[]): number {
+  function count(nodes: ExplainPlanNode[]): number {
     let c = nodes.length
     for (const n of nodes) {
       c += count(n.children || [])

--- a/src/components/explain-plan/ExplainPlanRawView.vue
+++ b/src/components/explain-plan/ExplainPlanRawView.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  raw: string
+  format: 'json' | 'text'
+}>()
+
+const displayContent = computed(() => {
+  if (props.format === 'json') {
+    try {
+      return JSON.stringify(JSON.parse(props.raw), null, 2)
+    }
+    catch {
+      return props.raw
+    }
+  }
+  return props.raw
+})
+</script>
+
+<template>
+  <pre class="text-xs leading-relaxed font-mono m-3 p-3 border rounded bg-muted/30 whitespace-pre overflow-auto">{{ displayContent }}</pre>
+</template>

--- a/src/components/explain-plan/ExplainPlanSummaryTable.vue
+++ b/src/components/explain-plan/ExplainPlanSummaryTable.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import type { ExplainPlanNode } from '@/types/explainPlan'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  nodes: ExplainPlanNode[]
+}>()
+
+type FlatRow = {
+  node: ExplainPlanNode
+  depth: number
+}
+
+function buildFlatRows(nodes: ExplainPlanNode[], depth = 0): FlatRow[] {
+  const rows: FlatRow[] = []
+  for (const node of nodes) {
+    rows.push({ node, depth })
+    rows.push(...buildFlatRows(node.children, depth + 1))
+  }
+  return rows
+}
+
+const flatRows = computed(() => buildFlatRows(props.nodes))
+</script>
+
+<template>
+  <div class="border rounded overflow-auto">
+    <table class="text-xs text-left min-w-[700px] w-full">
+      <thead class="text-muted-foreground bg-muted/70">
+        <tr>
+          <th class="font-medium px-2 py-1.5">
+            {{ t('pages.queries.explain.columnHeaders.nodeType') }}
+          </th>
+          <th class="font-medium px-2 py-1.5">
+            {{ t('pages.queries.explain.columnHeaders.relation') }}
+          </th>
+          <th class="font-medium px-2 py-1.5">
+            {{ t('pages.queries.explain.columnHeaders.index') }}
+          </th>
+          <th class="font-medium px-2 py-1.5">
+            {{ t('pages.queries.explain.columnHeaders.cost') }}
+          </th>
+          <th class="font-medium px-2 py-1.5">
+            {{ t('pages.queries.explain.columnHeaders.rows') }}
+          </th>
+          <th class="font-medium px-2 py-1.5">
+            {{ t('pages.queries.explain.columnHeaders.details') }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="row in flatRows"
+          :key="row.node.id"
+          class="border-t"
+        >
+          <td
+            class="font-medium px-2 py-1.5"
+            :style="{ paddingLeft: `${8 + row.depth * 20}px` }"
+          >
+            {{ row.node.title }}
+          </td>
+          <td class="text-muted-foreground px-2 py-1.5">
+            {{ row.node.relation || '-' }}
+          </td>
+          <td class="text-muted-foreground px-2 py-1.5">
+            {{ row.node.index || '-' }}
+          </td>
+          <td class="px-2 py-1.5 tabular-nums">
+            {{ row.node.cost || '-' }}
+          </td>
+          <td class="px-2 py-1.5 tabular-nums">
+            {{ row.node.rows || '-' }}
+          </td>
+          <td class="text-muted-foreground px-2 py-1.5">
+            {{ row.node.details.join('; ') || '-' }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/src/components/explain-plan/ExplainPlanSummaryTable.vue
+++ b/src/components/explain-plan/ExplainPlanSummaryTable.vue
@@ -3,11 +3,11 @@ import type { ExplainPlanNode } from '@/types/explainPlan'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n()
-
 const props = defineProps<{
   nodes: ExplainPlanNode[]
 }>()
+
+const { t } = useI18n()
 
 type FlatRow = {
   node: ExplainPlanNode

--- a/src/components/explain-plan/index.ts
+++ b/src/components/explain-plan/index.ts
@@ -1,0 +1,4 @@
+export { default as ExplainPlanNodeTree } from './ExplainPlanNodeTree.vue'
+export { default as ExplainPlanPanel } from './ExplainPlanPanel.vue'
+export { default as ExplainPlanRawView } from './ExplainPlanRawView.vue'
+export { default as ExplainPlanSummaryTable } from './ExplainPlanSummaryTable.vue'

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -584,6 +584,43 @@ export const enUS = {
         acknowledge: 'Keep as Orphan',
         close: 'Close Tab',
       },
+      explain: {
+        title: 'Explain Plan',
+        treeView: 'Tree',
+        summaryView: 'Summary',
+        rawView: 'Raw',
+        analyze: 'Explain Analyze',
+        running: 'Generating explain plan...',
+        empty: 'No explain plan data',
+        nodeCount: '{count} nodes',
+        summary: {
+          totalCost: 'Estimated total cost: {cost}',
+          mostExpensive: 'Most expensive: {node}',
+          noCostData: 'No cost data',
+        },
+        node: {
+          rowEstimate: 'e:{rows}',
+          actualRows: 'a:{rows}',
+          discrepancyWarning: 'Actual rows significantly exceed estimate ({actual} vs {estimated}, {ratio}x)',
+        },
+        error: {
+          parseFailed: 'Failed to parse explain plan',
+          noPlan: 'No explain plan returned from database',
+        },
+        tabLabels: {
+          results: 'Results',
+          explain: 'Explain',
+        },
+        analyzeToggle: 'Toggle EXPLAIN ANALYZE mode (currently: {mode})',
+        columnHeaders: {
+          nodeType: 'Node Type',
+          relation: 'Relation',
+          index: 'Index',
+          cost: 'Cost',
+          rows: 'Rows',
+          details: 'Details',
+        },
+      },
     },
     dataStudio: {
       title: 'Data Studio',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -565,6 +565,43 @@ export const zhCN = {
         acknowledge: '保持孤立',
         close: '关闭标签页',
       },
+      explain: {
+        title: '执行计划',
+        treeView: '树形',
+        summaryView: '概要',
+        rawView: '原始',
+        analyze: '分析执行',
+        running: '正在生成执行计划...',
+        empty: '暂无执行计划数据',
+        nodeCount: '{count} 个节点',
+        summary: {
+          totalCost: '预估总成本: {cost}',
+          mostExpensive: '最高成本: {node}',
+          noCostData: '无成本数据',
+        },
+        node: {
+          rowEstimate: '估:{rows}',
+          actualRows: '实:{rows}',
+          discrepancyWarning: '实际行数远超预估 ({actual} vs {estimated}, {ratio}倍)',
+        },
+        error: {
+          parseFailed: '执行计划解析失败',
+          noPlan: '数据库未返回执行计划',
+        },
+        tabLabels: {
+          results: '结果',
+          explain: '计划',
+        },
+        analyzeToggle: '切换 EXPLAIN ANALYZE 模式 (当前: {mode})',
+        columnHeaders: {
+          nodeType: '节点类型',
+          relation: '关系',
+          index: '索引',
+          cost: '成本',
+          rows: '行数',
+          details: '详情',
+        },
+      },
     },
     dataStudio: {
       title: '数据工作室',

--- a/src/pages/QueriesPage.vue
+++ b/src/pages/QueriesPage.vue
@@ -256,8 +256,22 @@ async function executeQuery(details?: StatementToExecute) {
   await tabStore.executeQuery(activeTab.value.id, sqlToExecute)
 }
 
-async function handleExplainQuery() {
-  // TODO: Implement explain query
+const explainAnalyzeMode = ref(false)
+
+async function handleExplainQuery(analyze = false) {
+  if (!activeTab.value || activeTab.value.orphanFromConnectionId)
+    return
+  if (!activeTab.value.content.trim())
+    return
+  const connId = getConnectionId()
+  if (!connId)
+    return
+  showResultPanel.value = true
+  await tabStore.explainQuery(activeTab.value.id, analyze)
+}
+
+function toggleExplainMode() {
+  explainAnalyzeMode.value = !explainAnalyzeMode.value
 }
 
 function getActiveDialect(): string | null {
@@ -353,6 +367,17 @@ function handleGlobalKeydown(e: KeyboardEvent) {
       e.preventDefault()
       e.stopPropagation()
       queryTabsRef.value?.triggerClose(tab.id)
+    }
+  }
+  if (e.key === 'F6') {
+    // Don't fire F6 when user is typing in an input/textarea/contenteditable
+    const target = e.target as HTMLElement
+    const isInput = target.tagName === 'INPUT'
+      || target.tagName === 'TEXTAREA'
+      || target.isContentEditable
+    if (!isInput) {
+      e.preventDefault()
+      handleExplainQuery(explainAnalyzeMode.value)
     }
   }
 }
@@ -795,8 +820,9 @@ function closeResultPanel() {
                       variant="ghost"
                       size="sm"
                       class="gap-1 h-7"
-                      :disabled="!activeTab"
-                      @click="handleExplainQuery"
+                      :class="{ 'text-violet-600': !explainAnalyzeMode, 'text-green-600': explainAnalyzeMode }"
+                      :disabled="!activeTab || activeTab.orphanFromConnectionId || activeTab.isExplaining"
+                      @click="handleExplainQuery(explainAnalyzeMode)"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M12 20h9" />
@@ -808,6 +834,25 @@ function closeResultPanel() {
                   <TooltipContent>
                     <p>{{ t('pages.queries.shortcuts.explain', { key: modifierKey }) }}</p>
                   </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      class="p-0 h-7 w-7"
+                      :class="explainAnalyzeMode ? 'text-green-600 bg-green-100 dark:text-green-300 dark:bg-green-900/30' : 'text-muted-foreground/50'"
+                      :disabled="!activeTab || activeTab.orphanFromConnectionId || activeTab.isExplaining"
+                      @click="toggleExplainMode"
+                    >
+                      <span class="text-xs font-bold">A</span>
+                    </Button>
+                  </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{{ t('pages.queries.explain.analyzeToggle', { mode: explainAnalyzeMode ? 'ON' : 'OFF' }) }}</p>
+                    </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
 
@@ -946,6 +991,9 @@ function closeResultPanel() {
               :sql="activeTab?.content"
               :connection-id="getConnectionId() ?? undefined"
               :database="activeTab?.database"
+              :explain-plan="activeTab?.explainPlan ?? null"
+              :is-explaining="activeTab?.isExplaining ?? false"
+              :explain-error="activeTab?.explainError ?? null"
               @close="closeResultPanel"
               @refresh="handleNewTab"
             />

--- a/src/pages/QueriesPage.vue
+++ b/src/pages/QueriesPage.vue
@@ -850,9 +850,9 @@ function closeResultPanel() {
                       <span class="text-xs font-bold">A</span>
                     </Button>
                   </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{{ t('pages.queries.explain.analyzeToggle', { mode: explainAnalyzeMode ? 'ON' : 'OFF' }) }}</p>
-                    </TooltipContent>
+                  <TooltipContent>
+                    <p>{{ t('pages.queries.explain.analyzeToggle', { mode: explainAnalyzeMode ? 'ON' : 'OFF' }) }}</p>
+                  </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
 

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -436,6 +436,7 @@ export const useTabStore = defineStore('tabs', {
           connectionId: connId,
           sql,
           analyze,
+          database: tab.database,
         })
 
         tab.explainPlan = parseExplainResult(

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -1,8 +1,10 @@
 import type { ApiError, ApiResponse } from '@/types/api'
+import type { ExplainResult } from '@/types/explainPlan'
 import { invoke } from '@tauri-apps/api/core'
 import { defineStore } from 'pinia'
 import { withMinLoadingTime } from '@/composables/useMinLoadingTime'
 import { isApiError, isApiSuccess } from '@/types/api'
+import { parseExplainResult } from '@/utils/explainPlanParser'
 import { useConnectionStore } from './connectionStore'
 import { useHistoryStore } from './historyStore'
 
@@ -50,6 +52,12 @@ export type QueryTab = {
   listingTab?: ListingTabMeta
   /** If set, this tab is orphaned from the specified connection and cannot execute queries */
   orphanFromConnectionId?: string
+  /** Parsed explain plan result */
+  explainPlan?: ExplainResult
+  /** Explain plan error message */
+  explainError?: string | null
+  /** Whether an explain query is currently running */
+  isExplaining?: boolean
 }
 
 type TabStoreState = {
@@ -401,6 +409,61 @@ export const useTabStore = defineStore('tabs', {
       }
     },
 
+    async explainQuery(tabId: string, analyze = false) {
+      const tab = this.tabs.find(t => t.id === tabId)
+      if (!tab || tab.orphanFromConnectionId)
+        return
+
+      const sql = tab.content
+      if (!sql.trim())
+        return
+
+      const connId = tab.connectionId
+      if (!connId)
+        return
+
+      tab.isExplaining = true
+      tab.explainError = undefined
+      tab.explainPlan = undefined
+
+      try {
+        const result = await invoke<{
+          database_type: string
+          raw: string
+          format: string
+          analyze: boolean
+        }>('explain_query', {
+          connectionId: connId,
+          sql,
+          analyze,
+        })
+
+        tab.explainPlan = parseExplainResult(
+          result.raw,
+          result.database_type,
+          result.format as 'json' | 'text',
+          result.analyze,
+        )
+        tab.explainError = undefined
+      }
+      catch (error) {
+        tab.explainPlan = undefined
+        tab.explainError = String(error)
+      }
+      finally {
+        tab.isExplaining = false
+      }
+    },
+
+    clearExplain(tabId: string) {
+      const tab = this.tabs.find(t => t.id === tabId)
+      if (tab) {
+        tab.explainPlan = undefined
+        tab.explainError = undefined
+        tab.isExplaining = false
+      }
+    },
+
     setActiveTab(tabId: string) {
       if (this.tabs.find(t => t.id === tabId)) {
         this.activeTabId = tabId
@@ -431,5 +494,19 @@ export const useTabStore = defineStore('tabs', {
 
   persist: {
     pick: ['tabs', 'activeTabId'],
+    serializer: {
+      serialize: (data: any) => {
+        if (data.tabs) {
+          data.tabs = data.tabs.map((t: any) => ({
+            ...t,
+            explainPlan: undefined,
+            explainError: undefined,
+            isExplaining: false,
+          }))
+        }
+        return JSON.stringify(data)
+      },
+      deserialize: (data: string) => JSON.parse(data),
+    },
   },
 })

--- a/src/types/explainPlan.ts
+++ b/src/types/explainPlan.ts
@@ -1,0 +1,47 @@
+/** A single node in the query execution plan tree. */
+export type ExplainPlanNode = {
+  /** Unique ID within the plan (e.g. "0", "0.1", "0.1.0"). */
+  id: string
+  /** Display title (e.g. "Seq Scan on users"). */
+  title: string
+  /** Node type (e.g. "Seq Scan", "Index Scan", "Hash Join"). */
+  nodeType: string
+  /** Relation/table name. */
+  relation?: string
+  /** Index name (if applicable). */
+  index?: string
+  /** Estimated startup cost. */
+  startupCost?: number
+  /** Estimated total cost. */
+  totalCost?: number
+  /** Display cost string (e.g. "0.00..35.50"). */
+  cost?: string
+  /** Estimated number of rows. */
+  rows?: number
+  /** Actual rows returned (only with EXPLAIN ANALYZE). */
+  actualRows?: number
+  /** Estimated row width. */
+  width?: number
+  /** Additional details (e.g. "Filter: (status = 'active')"). */
+  details: string[]
+  /** Child plan nodes. */
+  children: ExplainPlanNode[]
+}
+
+/** Parsed explain plan result. */
+export type ExplainResult = {
+  /** Database type identifier. */
+  databaseType: string
+  /** Raw output from the backend. */
+  raw: string
+  /** Format of raw output. */
+  format: 'json' | 'text'
+  /** Parsed plan tree nodes. */
+  nodes: ExplainPlanNode[]
+  /** Total estimated cost across all nodes. */
+  totalCost?: number
+  /** Name of the most expensive node. */
+  mostExpensiveNode?: string
+  /** Whether this was an EXPLAIN ANALYZE query. */
+  analyze: boolean
+}

--- a/src/utils/explainPlanParser.ts
+++ b/src/utils/explainPlanParser.ts
@@ -1,0 +1,649 @@
+import type { ExplainPlanNode, ExplainResult } from '@/types/explainPlan'
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse raw EXPLAIN output into structured ExplainResult.
+ */
+export function parseExplainResult(raw: string, databaseType: string, format: 'json' | 'text', analyze: boolean): ExplainResult {
+  let nodes: ExplainPlanNode[]
+
+  if (format === 'json') {
+    if (databaseType === 'postgresql' || databaseType === 'postgres') {
+      nodes = parsePostgresJson(JSON.parse(raw))
+    }
+    else if (databaseType === 'mysql' || databaseType === 'mariadb') {
+      nodes = parseMySqlJson(JSON.parse(raw))
+    }
+    else {
+      nodes = parseGenericText(raw)
+    }
+  }
+  else {
+    if (databaseType === 'sqlite') {
+      nodes = parseSqliteText(raw)
+    }
+    else if (databaseType === 'mysql' || databaseType === 'mariadb') {
+      nodes = parseMySqlAnalyzeText(raw)
+    }
+    else if (databaseType === 'sqlserver' || databaseType === 'mssql') {
+      nodes = parseSqlServerText(raw)
+    }
+    else if (
+      databaseType === 'duckdb'
+      || databaseType === 'clickhouse'
+    ) {
+      nodes = parseGenericText(raw)
+    }
+    else {
+      nodes = parseGenericText(raw)
+    }
+  }
+
+  const totalCost = calculateTotalCost(nodes)
+  const mostExpensiveNode = findMostExpensiveNode(nodes)
+
+  return {
+    databaseType,
+    raw,
+    format,
+    nodes,
+    totalCost,
+    mostExpensiveNode,
+    analyze,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PostgreSQL JSON parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively parse a PostgreSQL plan object into ExplainPlanNode.
+ */
+function parsePostgresPlan(plan: Record<string, any>, id: string): ExplainPlanNode {
+  const nodeType: string = plan['Node Type'] ?? 'Unknown'
+  const relation: string | undefined = plan['Relation Name']
+  const index: string | undefined = plan['Index Name']
+  const startupCost: number | undefined = plan['Startup Cost']
+  const totalCost: number | undefined = plan['Total Cost']
+  const rows: number | undefined = plan['Plan Rows']
+  const actualRows: number | undefined = plan['Actual Rows']
+  const width: number | undefined = plan['Plan Width']
+
+  const cost: string | undefined
+    = startupCost !== undefined && totalCost !== undefined
+      ? `${startupCost.toFixed(2)}..${totalCost.toFixed(2)}`
+      : undefined
+
+  const title = relation ? `${nodeType} on ${relation}` : nodeType
+
+  // Collect details from extra fields
+  const details: string[] = []
+  const extraFields = [
+    'Index Cond',
+    'Filter',
+    'Join Type',
+    'Strategy',
+    'Sort Key',
+    'Recheck Cond',
+    'Hash Cond',
+    'Merge Cond',
+  ]
+  for (const field of extraFields) {
+    const val = plan[field]
+    if (val !== undefined) {
+      details.push(`${field}: ${Array.isArray(val) ? val.join(', ') : String(val)}`)
+    }
+  }
+
+  // Recurse into child plans
+  const childPlans: Record<string, any>[] = plan.Plans ?? []
+  const children = childPlans.map((child, i) =>
+    parsePostgresPlan(child, `${id}.${i}`),
+  )
+
+  return {
+    id,
+    title,
+    nodeType,
+    relation,
+    index,
+    startupCost,
+    totalCost,
+    cost,
+    rows,
+    actualRows,
+    width,
+    details,
+    children,
+  }
+}
+
+/**
+ * Parse PostgreSQL EXPLAIN (FORMAT JSON) output.
+ */
+export function parsePostgresJson(parsed: any): ExplainPlanNode[] {
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return []
+  }
+
+  return parsed.map((entry, i) => {
+    const plan = entry.Plan ?? entry
+    return parsePostgresPlan(plan, String(i))
+  })
+}
+
+// ---------------------------------------------------------------------------
+// MySQL JSON parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract an ExplainPlanNode from a MySQL table object.
+ */
+function parseMySqlTable(table: Record<string, any>, id: string, extraDetails?: string[]): ExplainPlanNode {
+  const nodeType: string = table.access_type ?? 'Unknown'
+  const relation: string | undefined = table.table_name
+  const index: string | undefined = table.key
+  const rows: number | undefined = table.rows_examined_per_scan
+  const totalCost: number | undefined = table.cost_info?.query_cost
+    ? Number.parseFloat(table.cost_info.query_cost)
+    : undefined
+
+  const details: string[] = [...(extraDetails ?? [])]
+  if (table.attached_condition) {
+    details.push(table.attached_condition)
+  }
+  if (table.used_columns) {
+    details.push(`Columns: ${(table.used_columns as string[]).join(', ')}`)
+  }
+
+  const title = relation ? `${nodeType} on ${relation}` : nodeType
+
+  const materialized = table.materialized_from_subquery
+  if (materialized) {
+    const innerBlock = materialized.query_block as Record<string, any> | undefined
+    if (innerBlock) {
+      const childNodes = parseMySqlQueryBlock(innerBlock, id)
+      if (childNodes.length > 0) {
+        return childNodes[0]
+      }
+    }
+  }
+
+  return {
+    id,
+    title,
+    nodeType,
+    relation,
+    index,
+    totalCost,
+    rows,
+    details,
+    children: [],
+  }
+}
+
+/**
+ * Parse a MySQL query_block object, extracting tables from
+ * nested_loop, ordering_operation, grouping_operation, or direct table.
+ */
+function parseMySqlQueryBlock(block: Record<string, any>, baseId: string): ExplainPlanNode[] {
+  const nodes: ExplainPlanNode[] = []
+  let counter = 0
+
+  // Nested loop join — array of table objects
+  const nestedLoop = block.nested_loop as Record<string, any>[] | undefined
+  if (nestedLoop) {
+    const children: ExplainPlanNode[] = []
+    for (const item of nestedLoop) {
+      if (item.table) {
+        children.push(parseMySqlTable(item.table, `${baseId}.${counter++}`))
+      }
+    }
+    // Wrap in a synthetic join parent node for tree hierarchy
+    return [{
+      id: baseId,
+      title: 'Nested Loop Join',
+      nodeType: 'Nested Loop Join',
+      details: children.length > 1 ? [] : ['Single table'],
+      children,
+    }]
+  }
+
+  // Ordering operation wraps a table with filesort
+  const orderingOp = block.ordering_operation as Record<string, any> | undefined
+  if (orderingOp) {
+    if (orderingOp.table) {
+      const tableNode = parseMySqlTable(
+        orderingOp.table,
+        `${baseId}.${counter++}`,
+        orderingOp.using_filesort ? ['Using filesort'] : undefined,
+      )
+      nodes.push(tableNode)
+    }
+    return nodes
+  }
+
+  // Grouping operation wraps a table
+  const groupingOp = block.grouping_operation as Record<string, any> | undefined
+  if (groupingOp) {
+    if (groupingOp.table) {
+      nodes.push(parseMySqlTable(groupingOp.table, `${baseId}.${counter++}`))
+    }
+    return nodes
+  }
+
+  // Direct table
+  const table = block.table as Record<string, any> | undefined
+  if (table) {
+    nodes.push(parseMySqlTable(table, `${baseId}.${counter++}`))
+  }
+
+  return nodes
+}
+
+/**
+ * Parse MySQL EXPLAIN FORMAT=JSON output.
+ */
+export function parseMySqlJson(parsed: any): ExplainPlanNode[] {
+  const queryBlock = parsed.query_block
+  if (!queryBlock) {
+    return []
+  }
+
+  return parseMySqlQueryBlock(queryBlock, '0')
+}
+
+// ---------------------------------------------------------------------------
+// SQLite text parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single SQLite plan line detail to extract table and index.
+ */
+function parseSqliteDetail(detail: string): { nodeType: string, relation?: string, index?: string } {
+  // Patterns ordered by specificity (longest match first)
+  const fullOpMatch = detail.match(/^\d*\s*(USE\s+TEMP\s+B-TREE\s+FOR\s+ORDER\s+BY|EXECUTE\s+CORRELATED\s+SCALAR\s+SUBQUERY)/)
+  if (fullOpMatch) {
+    return { nodeType: fullOpMatch[1] }
+  }
+
+  const tableMatch = detail.match(/^\d*\s*(SCAN\s+TABLE|SEARCH\s+TABLE)\s+(\w+)(?:\s+USING\s+INDEX\s+(\w+))?/)
+  if (tableMatch) {
+    return {
+      nodeType: tableMatch[1],
+      relation: tableMatch[2],
+      index: tableMatch[3],
+    }
+  }
+
+  return { nodeType: detail.split(/\s+/)[0] ?? detail }
+}
+
+/**
+ * Parse SQLite EXPLAIN QUERY PLAN text output.
+ * Format: pipe-delimited columns: id|parent|notused|detail
+ */
+export function parseSqliteText(text: string): ExplainPlanNode[] {
+  const lines = text.trim().split('\n').filter(l => l.trim().length > 0)
+  if (lines.length === 0) {
+    return []
+  }
+
+  // Parse all lines first
+  const rows = lines.map((line) => {
+    const parts = line.split('|').map(s => s.trim())
+    if (parts.length < 4) {
+      return null
+    }
+    return {
+      id: parts[0],
+      parent: parts[1],
+      notused: parts[2],
+      detail: parts.slice(3).join('|'),
+    }
+  }).filter((r): r is NonNullable<typeof r> => r !== null)
+
+  if (rows.length === 0) {
+    return []
+  }
+
+  // Build nodes
+  const nodeMap = new Map<string, ExplainPlanNode>()
+  for (const row of rows) {
+    const { nodeType, relation, index } = parseSqliteDetail(row.detail)
+    const node: ExplainPlanNode = {
+      id: row.id,
+      title: relation ? `${nodeType} on ${relation}` : nodeType,
+      nodeType,
+      relation,
+      index,
+      details: [row.detail],
+      children: [],
+    }
+    nodeMap.set(row.id, node)
+  }
+
+  // Link children to parents
+  const roots: ExplainPlanNode[] = []
+  for (const row of rows) {
+    const node = nodeMap.get(row.id)!
+    if (row.parent === '0') {
+      roots.push(node)
+    }
+    else {
+      const parent = nodeMap.get(row.parent)
+      if (parent) {
+        parent.children.push(node)
+      }
+      else {
+        roots.push(node)
+      }
+    }
+  }
+
+  return roots
+}
+
+// ---------------------------------------------------------------------------
+// SQL Server text parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a SQL Server StmtText line to extract operator info.
+ */
+function parseSqlServerOperator(line: string): { nodeType: string, relation?: string, index?: string, detail: string } {
+  // Strip leading |-- and whitespace
+  const cleaned = line.replace(/^\s*\|--\s*/, '').trim()
+
+  // Pattern: "OperatorName(OBJECT:([schema].[table]), ...)"
+  // Or "OperatorName(Inner Join, ...)"
+  const parenIndex = cleaned.indexOf('(')
+  const nodeType = parenIndex > 0 ? cleaned.substring(0, parenIndex).trim() : cleaned.trim()
+
+  const detail = cleaned
+
+  // Extract identifiers from OBJECT:([db].[schema].[table]) or OBJECT:([table]) or OBJECT:([table].[index])
+  let relation: string | undefined
+  let index: string | undefined
+
+  const objMatch = detail.match(/OBJECT:\(([^)]+)\)/)
+  if (objMatch) {
+    // Split by `].[` or `]` separators
+    const parts = objMatch[1]
+      .split(/\]\.\[|\]|\[/)
+      .map(s => s.replace(/[[\]]/g, '').trim())
+      .filter(s => s.length > 0)
+
+    if (nodeType === 'Index Seek' || nodeType === 'Index Scan') {
+      // Format: [db].[schema].[table].[index] or [schema].[table].[index]
+      if (parts.length >= 3) {
+        relation = parts[parts.length - 2] // second-to-last is the table
+        index = parts[parts.length - 1] // last is the index name
+      }
+      else if (parts.length === 2) {
+        relation = parts[0]
+        index = parts[1]
+      }
+    }
+    else {
+      // Table Scan or other operations: [db].[schema].[table] or [table]
+      if (parts.length >= 2) {
+        relation = parts[parts.length - 1] // last part is the table name
+      }
+      else if (parts.length === 1) {
+        relation = parts[0]
+      }
+    }
+  }
+
+  return { nodeType, relation, index, detail }
+}
+
+/**
+ * Parse SQL Server SHOWPLAN text output.
+ */
+export function parseSqlServerText(text: string): ExplainPlanNode[] {
+  const lines = text.split('\n').filter(l => l.trim().length > 0)
+  if (lines.length === 0) {
+    return []
+  }
+
+  const nodes: ExplainPlanNode[] = []
+  let idCounter = 0
+
+  for (const line of lines) {
+    // Only process lines with plan operators
+    if (!line.includes('|--')) {
+      continue
+    }
+
+    const { nodeType, relation, index, detail } = parseSqlServerOperator(line)
+
+    const title = relation ? `${nodeType} on ${relation}` : nodeType
+
+    nodes.push({
+      id: String(idCounter++),
+      title,
+      nodeType,
+      relation,
+      index,
+      details: [detail],
+      children: [],
+    })
+  }
+
+  return nodes
+}
+
+// ---------------------------------------------------------------------------
+// Generic text parser (DuckDB / ClickHouse)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse DuckDB/ClickHouse generic EXPLAIN text output.
+ */
+export function parseGenericText(text: string): ExplainPlanNode[] {
+  const lines = text.split('\n')
+    .map(l => l.replace(/[─┐└├│┌┬┤┼╴╵╶╷╸╹╺╻╼╽╾╿■]/g, '').trim())
+    .filter(l => l.length > 0 && !l.match(/^[\s\-_.]+$/))
+
+  if (lines.length === 0) {
+    return []
+  }
+
+  const deduped: string[] = []
+  for (const line of lines) {
+    if (deduped.length === 0 || line !== deduped[deduped.length - 1]) {
+      deduped.push(line)
+    }
+  }
+
+  return deduped.map((line, i) => {
+    const cleanLine = line.replace(/\s+/g, ' ').trim()
+    return {
+      id: String(i),
+      title: cleanLine,
+      nodeType: cleanLine.split(/\s+/)[0] ?? cleanLine,
+      details: [cleanLine],
+      children: [],
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Get CSS color class based on cost percentage.
+ * Green: < 10%, Yellow: 10-40%, Red: > 40%
+ */
+export function getCostColor(cost: number, totalCost: number): 'green' | 'yellow' | 'red' {
+  if (totalCost <= 0) {
+    return 'green'
+  }
+  const pct = (cost / totalCost) * 100
+  if (pct < 10) {
+    return 'green'
+  }
+  if (pct < 40) {
+    return 'yellow'
+  }
+  return 'red'
+}
+
+/**
+ * Find the most expensive node name.
+ */
+export function findMostExpensiveNode(nodes: ExplainPlanNode[]): string | undefined {
+  let maxCost = -1
+  let maxNode: ExplainPlanNode | undefined
+
+  const visit = (node: ExplainPlanNode) => {
+    if (node.totalCost !== undefined && node.totalCost > maxCost) {
+      maxCost = node.totalCost
+      maxNode = node
+    }
+    for (const child of node.children) {
+      visit(child)
+    }
+  }
+
+  for (const node of nodes) {
+    visit(node)
+  }
+
+  return maxNode?.title
+}
+
+/**
+ * Calculate total cost from all root nodes.
+ * Recurses into children when a node has no cost itself but has children with costs.
+ */
+export function calculateTotalCost(nodes: ExplainPlanNode[]): number {
+  const visit = (n: ExplainPlanNode): number => {
+    if (n.totalCost !== undefined && n.totalCost > 0)
+      return n.totalCost
+    if (n.children.length > 0)
+      return n.children.reduce((s, c) => s + visit(c), 0)
+    return 0
+  }
+  return nodes.reduce((sum, n) => sum + visit(n), 0)
+}
+
+/**
+ * Flatten tree to array (for summary table).
+ */
+export function flattenNodes(nodes: ExplainPlanNode[]): ExplainPlanNode[] {
+  const result: ExplainPlanNode[] = []
+
+  const walk = (node: ExplainPlanNode) => {
+    result.push(node)
+    for (const child of node.children) {
+      walk(child)
+    }
+  }
+
+  for (const node of nodes) {
+    walk(node)
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// MySQL EXPLAIN ANALYZE TREE text parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse MySQL EXPLAIN ANALYZE TREE-format output.
+ * Format: lines prefixed with `->` where indentation indicates nesting depth.
+ * E.g.:
+ *   -> Nested loop inner join  (cost=1.0 rows=1)
+ *       -> Table scan on users  (cost=0.5 rows=2)
+ *       -> Index lookup on orders  (cost=0.5 rows=1)
+ * Each line may end with "(cost=X rows=Y)" or "(cost=X..Y rows=Z)".
+ */
+export function parseMySqlAnalyzeText(text: string): ExplainPlanNode[] {
+  const lines = text.split('\n').filter(l => l.includes('->'))
+  if (lines.length === 0)
+    return []
+
+  // Find the base indentation level from the first `->` line
+  const baseIndent = Math.min(...lines.map((l) => {
+    const idx = l.indexOf('->')
+    return idx >= 0 ? idx : Infinity
+  }))
+
+  const rootNodes: ExplainPlanNode[] = []
+  const stack: { node: ExplainPlanNode, depth: number }[] = []
+  let idCounter = 0
+
+  for (const line of lines) {
+    const arrowIdx = line.indexOf('->')
+    if (arrowIdx < 0)
+      continue
+
+    const indent = arrowIdx - baseIndent
+    const depth = Math.max(0, Math.round(indent / 4))
+    const content = line.substring(arrowIdx + 2).trim()
+
+    // Parse cost and rows from trailing "(cost=... rows=...)"
+    const costMatch = content.match(/\(cost=([\d.]+(?:\.\.[\d.]+)?)\s+rows=([\d.]+)\)/)
+    const costStr = costMatch?.[1]
+    const totalCost = costStr ? Number.parseFloat(costStr.replace('..', '.')) : undefined
+    const rows = costMatch?.[2] ? Number.parseFloat(costMatch[2]) : undefined
+
+    // Extract details (text before the cost parentheses)
+    let nodeType = content
+    let details: string[] = []
+    if (costMatch) {
+      nodeType = content.substring(0, content.indexOf('(cost=')).trim()
+      const extra = content.substring(content.indexOf(')') + 1).trim()
+      if (extra)
+        details = [extra]
+    }
+
+    const id = String(idCounter++)
+    // Extract relation: everything after " on ", minus any " using ..." suffix
+    let relation: string | undefined
+    if (nodeType.includes(' on ')) {
+      const afterOn = nodeType.split(/ on /i).slice(1).join(' on ')
+      const usingIdx = afterOn.search(/ using /i)
+      relation = usingIdx >= 0 ? afterOn.substring(0, usingIdx).trim() : afterOn
+      if (usingIdx >= 0) {
+        details = [...details, afterOn.substring(usingIdx).trim()]
+      }
+    }
+    const node: ExplainPlanNode = {
+      id,
+      title: nodeType,
+      nodeType: nodeType.split(/ on /i)[0] || nodeType,
+      relation,
+      totalCost,
+      cost: costStr,
+      rows,
+      details,
+      children: [],
+    }
+
+    // Build tree from depth stack
+    while (stack.length > 0 && stack[stack.length - 1].depth >= depth)
+      stack.pop()
+
+    if (stack.length === 0) {
+      rootNodes.push(node)
+    }
+    else {
+      stack[stack.length - 1].node.children.push(node)
+    }
+
+    stack.push({ node, depth })
+  }
+
+  return rootNodes
+}

--- a/src/utils/explainPlanParser.ts
+++ b/src/utils/explainPlanParser.ts
@@ -593,9 +593,13 @@ export function parseMySqlAnalyzeText(text: string): ExplainPlanNode[] {
     const content = line.substring(arrowIdx + 2).trim()
 
     // Parse cost and rows from trailing "(cost=... rows=...)"
-    const costMatch = content.match(/\(cost=([\d.]+(?:\.\.[\d.]+)?)\s+rows=([\d.]+)\)/)
+    const costMatch = content.match(/\(cost=([\d.]+)\s+rows=([\d.]+)\)/)
     const costStr = costMatch?.[1]
-    const totalCost = costStr ? Number.parseFloat(costStr.replace('..', '.')) : undefined
+    const totalCost = costStr
+      ? Number.parseFloat(
+          costStr.includes('..') ? costStr.split('..')[1] : costStr,
+        )
+      : undefined
     const rows = costMatch?.[2] ? Number.parseFloat(costMatch[2]) : undefined
 
     // Extract details (text before the cost parentheses)

--- a/tests/explainPlanParser.test.ts
+++ b/tests/explainPlanParser.test.ts
@@ -1,0 +1,1092 @@
+import type { ExplainPlanNode } from '@/types/explainPlan'
+import {
+  calculateTotalCost,
+  findMostExpensiveNode,
+  flattenNodes,
+  getCostColor,
+  parseExplainResult,
+  parseGenericText,
+  parseMySqlAnalyzeText,
+  parseMySqlJson,
+  parsePostgresJson,
+  parseSqliteText,
+  parseSqlServerText,
+} from '@/utils/explainPlanParser'
+
+// ---------------------------------------------------------------------------
+// PostgreSQL JSON parser tests
+// ---------------------------------------------------------------------------
+
+describe('parsePostgresJson', () => {
+  it('parses a simple Seq Scan', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Seq Scan',
+          'Relation Name': 'users',
+          'Startup Cost': 0.00,
+          'Total Cost': 35.50,
+          'Plan Rows': 250,
+          'Plan Width': 36,
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('Seq Scan')
+    expect(n.relation).toBe('users')
+    expect(n.startupCost).toBe(0.00)
+    expect(n.totalCost).toBe(35.50)
+    expect(n.rows).toBe(250)
+    expect(n.width).toBe(36)
+    expect(n.cost).toBe('0.00..35.50')
+    expect(n.children).toHaveLength(0)
+  })
+
+  it('parses an Index Scan with filter', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Index Scan',
+          'Relation Name': 'orders',
+          'Index Name': 'idx_orders_status',
+          'Startup Cost': 0.25,
+          'Total Cost': 12.75,
+          'Plan Rows': 50,
+          'Plan Width': 24,
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('Index Scan')
+    expect(n.relation).toBe('orders')
+    expect(n.index).toBe('idx_orders_status')
+    expect(n.startupCost).toBe(0.25)
+    expect(n.totalCost).toBe(12.75)
+  })
+
+  it('parses a Nested Loop join with two children', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Nested Loop',
+          'Startup Cost': 0.50,
+          'Total Cost': 95.00,
+          'Plan Rows': 100,
+          'Plan Width': 48,
+          'Plans': [
+            {
+              'Node Type': 'Seq Scan',
+              'Relation Name': 'users',
+              'Startup Cost': 0.00,
+              'Total Cost': 35.50,
+              'Plan Rows': 250,
+              'Plan Width': 36,
+            },
+            {
+              'Node Type': 'Index Scan',
+              'Relation Name': 'orders',
+              'Index Name': 'idx_orders_user',
+              'Startup Cost': 0.15,
+              'Total Cost': 0.30,
+              'Plan Rows': 1,
+              'Plan Width': 12,
+            },
+          ],
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const parent = nodes[0]
+    expect(parent.nodeType).toBe('Nested Loop')
+    expect(parent.children).toHaveLength(2)
+    expect(parent.children[0].nodeType).toBe('Seq Scan')
+    expect(parent.children[0].relation).toBe('users')
+    expect(parent.children[1].nodeType).toBe('Index Scan')
+    expect(parent.children[1].relation).toBe('orders')
+  })
+
+  it('parses a Hash Join with two children', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Hash Join',
+          'Join Type': 'INNER',
+          'Startup Cost': 5.00,
+          'Total Cost': 200.00,
+          'Plan Rows': 500,
+          'Plan Width': 72,
+          'Plans': [
+            {
+              'Node Type': 'Seq Scan',
+              'Relation Name': 'customers',
+              'Startup Cost': 0.00,
+              'Total Cost': 45.00,
+              'Plan Rows': 300,
+              'Plan Width': 36,
+            },
+            {
+              'Node Type': 'Hash',
+              'Startup Cost': 80.00,
+              'Total Cost': 80.00,
+              'Plan Rows': 200,
+              'Plan Width': 36,
+              'Plans': [
+                {
+                  'Node Type': 'Seq Scan',
+                  'Relation Name': 'orders',
+                  'Startup Cost': 0.00,
+                  'Total Cost': 80.00,
+                  'Plan Rows': 200,
+                  'Plan Width': 36,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const join = nodes[0]
+    expect(join.nodeType).toBe('Hash Join')
+    expect(join.children).toHaveLength(2)
+    expect(join.children[1].nodeType).toBe('Hash')
+    expect(join.children[1].children).toHaveLength(1)
+    expect(join.children[1].children[0].nodeType).toBe('Seq Scan')
+    expect(join.children[1].children[0].relation).toBe('orders')
+  })
+
+  it('parses Aggregate with Sort', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Aggregate',
+          'Strategy': 'Sorted',
+          'Startup Cost': 100.00,
+          'Total Cost': 100.01,
+          'Plan Rows': 1,
+          'Plan Width': 8,
+          'Plans': [
+            {
+              'Node Type': 'Sort',
+              'Startup Cost': 95.00,
+              'Total Cost': 98.00,
+              'Plan Rows': 250,
+              'Plan Width': 36,
+              'Sort Key': ['name ASC'],
+              'Plans': [
+                {
+                  'Node Type': 'Seq Scan',
+                  'Relation Name': 'users',
+                  'Startup Cost': 0.00,
+                  'Total Cost': 35.50,
+                  'Plan Rows': 250,
+                  'Plan Width': 36,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const agg = nodes[0]
+    expect(agg.nodeType).toBe('Aggregate')
+    expect(agg.children).toHaveLength(1)
+    expect(agg.children[0].nodeType).toBe('Sort')
+    expect(agg.children[0].children).toHaveLength(1)
+    expect(agg.children[0].children[0].nodeType).toBe('Seq Scan')
+  })
+
+  it('parses EXPLAIN ANALYZE with actual rows', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Seq Scan',
+          'Relation Name': 'users',
+          'Startup Cost': 0.00,
+          'Total Cost': 35.50,
+          'Plan Rows': 250,
+          'Plan Width': 36,
+          'Actual Rows': 180,
+          'Actual Startup Time': 0.02,
+          'Actual Total Time': 0.15,
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.actualRows).toBe(180)
+    expect(n.nodeType).toBe('Seq Scan')
+  })
+
+  it('parses deeply nested plan (3+ levels)', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Sort',
+          'Startup Cost': 500.00,
+          'Total Cost': 505.00,
+          'Plan Rows': 1000,
+          'Plan Width': 48,
+          'Plans': [
+            {
+              'Node Type': 'Hash Join',
+              'Startup Cost': 200.00,
+              'Total Cost': 450.00,
+              'Plan Rows': 1000,
+              'Plan Width': 48,
+              'Plans': [
+                {
+                  'Node Type': 'Seq Scan',
+                  'Relation Name': 'a',
+                  'Startup Cost': 0.00,
+                  'Total Cost': 100.00,
+                  'Plan Rows': 500,
+                  'Plan Width': 24,
+                },
+                {
+                  'Node Type': 'Hash',
+                  'Startup Cost': 300.00,
+                  'Total Cost': 300.00,
+                  'Plan Rows': 500,
+                  'Plan Width': 24,
+                  'Plans': [
+                    {
+                      'Node Type': 'Index Only Scan',
+                      'Relation Name': 'b',
+                      'Index Name': 'idx_b_key',
+                      'Startup Cost': 0.00,
+                      'Total Cost': 200.00,
+                      'Plan Rows': 500,
+                      'Plan Width': 24,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    // Level 1: Sort -> Hash Join -> [Seq Scan, Hash -> Index Only Scan]
+    expect(nodes[0].nodeType).toBe('Sort')
+    expect(nodes[0].children[0].nodeType).toBe('Hash Join')
+    expect(nodes[0].children[0].children[0].nodeType).toBe('Seq Scan')
+    expect(nodes[0].children[0].children[1].nodeType).toBe('Hash')
+    expect(nodes[0].children[0].children[1].children[0].nodeType).toBe('Index Only Scan')
+  })
+
+  it('returns empty array for empty plan', () => {
+    const nodes = parsePostgresJson([])
+    expect(nodes).toEqual([])
+  })
+
+  it('handles plan with missing cost fields', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Result',
+          'Plan Rows': 1,
+          'Plan Width': 0,
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('Result')
+    expect(n.startupCost).toBeUndefined()
+    expect(n.totalCost).toBeUndefined()
+    expect(n.cost).toBeUndefined()
+  })
+
+  it('handles multiple statements gracefully', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Seq Scan',
+          'Relation Name': 'a',
+          'Startup Cost': 0.00,
+          'Total Cost': 10.00,
+          'Plan Rows': 100,
+          'Plan Width': 4,
+        },
+      },
+      {
+        Plan: {
+          'Node Type': 'Index Scan',
+          'Relation Name': 'b',
+          'Startup Cost': 0.00,
+          'Total Cost': 5.00,
+          'Plan Rows': 50,
+          'Plan Width': 8,
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(2)
+    expect(nodes[0].nodeType).toBe('Seq Scan')
+    expect(nodes[1].nodeType).toBe('Index Scan')
+  })
+
+  it('handles Index Only Scan with filter', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Index Only Scan',
+          'Relation Name': 'products',
+          'Index Name': 'idx_products_category',
+          'Startup Cost': 0.10,
+          'Total Cost': 25.00,
+          'Plan Rows': 80,
+          'Plan Width': 16,
+          'Index Cond': '(category = 5)',
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('Index Only Scan')
+    expect(n.relation).toBe('products')
+    expect(n.details).toContain('Index Cond: (category = 5)')
+  })
+
+  it('handles Bitmap Heap Scan with Bitmap Index Scan child', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Bitmap Heap Scan',
+          'Relation Name': 'logs',
+          'Startup Cost': 10.00,
+          'Total Cost': 100.00,
+          'Plan Rows': 500,
+          'Plan Width': 32,
+          'Recheck Cond': '(level > 1)',
+          'Plans': [
+            {
+              'Node Type': 'Bitmap Index Scan',
+              'Index Name': 'idx_logs_level',
+              'Startup Cost': 0.00,
+              'Total Cost': 5.00,
+              'Plan Rows': 500,
+              'Plan Width': 0,
+            },
+          ],
+        },
+      },
+    ])
+    const nodes = parsePostgresJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].nodeType).toBe('Bitmap Heap Scan')
+    expect(nodes[0].children).toHaveLength(1)
+    expect(nodes[0].children[0].nodeType).toBe('Bitmap Index Scan')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MySQL JSON parser tests
+// ---------------------------------------------------------------------------
+
+describe('parseMySqlJson', () => {
+  it('parses a simple table access (ALL)', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        table: {
+          table_name: 'users',
+          access_type: 'ALL',
+          rows_examined_per_scan: 1000,
+          cost_info: {
+            query_cost: '105.00',
+          },
+          used_columns: ['id', 'name', 'email'],
+        },
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('ALL')
+    expect(n.relation).toBe('users')
+    expect(n.rows).toBe(1000)
+    expect(n.totalCost).toBe(105.00)
+  })
+
+  it('parses a table with WHERE condition and index lookup', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        table: {
+          table_name: 'orders',
+          access_type: 'ref',
+          possible_keys: ['idx_orders_user'],
+          key: 'idx_orders_user',
+          rows_examined_per_scan: 5,
+          cost_info: {
+            query_cost: '2.50',
+          },
+          used_columns: ['id', 'user_id', 'total'],
+          attached_condition: '(orders.user_id = 123)',
+        },
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('ref')
+    expect(n.relation).toBe('orders')
+    expect(n.index).toBe('idx_orders_user')
+    expect(n.rows).toBe(5)
+    expect(n.details).toContain('(orders.user_id = 123)')
+  })
+
+  it('parses a nested loop join', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        nested_loop: [
+          {
+            table: {
+              table_name: 'users',
+              access_type: 'ALL',
+              rows_examined_per_scan: 100,
+              cost_info: { query_cost: '10.00' },
+              used_columns: ['id'],
+            },
+          },
+          {
+            table: {
+              table_name: 'orders',
+              access_type: 'ref',
+              key: 'idx_orders_user',
+              rows_examined_per_scan: 10,
+              cost_info: { query_cost: '1.50' },
+              used_columns: ['id', 'user_id'],
+              attached_condition: '(orders.user_id = users.id)',
+            },
+          },
+        ],
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].nodeType).toBe('Nested Loop Join')
+    expect(nodes[0].children).toHaveLength(2)
+    expect(nodes[0].children[0].nodeType).toBe('ALL')
+    expect(nodes[0].children[0].relation).toBe('users')
+    expect(nodes[0].children[1].nodeType).toBe('ref')
+    expect(nodes[0].children[1].relation).toBe('orders')
+  })
+
+  it('parses a table with ordering_operation', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        ordering_operation: {
+          using_filesort: true,
+          table: {
+            table_name: 'logs',
+            access_type: 'ALL',
+            rows_examined_per_scan: 5000,
+            cost_info: { query_cost: '500.00' },
+            used_columns: ['id', 'timestamp'],
+          },
+        },
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('ALL')
+    expect(n.relation).toBe('logs')
+    expect(n.details).toContain('Using filesort')
+  })
+
+  it('parses a table with grouping_operation', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        grouping_operation: {
+          table: {
+            table_name: 'sales',
+            access_type: 'index',
+            key: 'idx_sales_date',
+            rows_examined_per_scan: 200,
+            cost_info: { query_cost: '30.00' },
+            used_columns: ['date', 'amount'],
+          },
+        },
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('index')
+    expect(n.relation).toBe('sales')
+    expect(n.index).toBe('idx_sales_date')
+  })
+
+  it('parses an eq_ref index lookup', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        table: {
+          table_name: 'customers',
+          access_type: 'eq_ref',
+          key: 'PRIMARY',
+          rows_examined_per_scan: 1,
+          cost_info: { query_cost: '1.00' },
+          used_columns: ['id', 'name'],
+          attached_condition: '(customers.id = 42)',
+        },
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].nodeType).toBe('eq_ref')
+    expect(nodes[0].index).toBe('PRIMARY')
+    expect(nodes[0].rows).toBe(1)
+  })
+
+  it('parses a materialized subquery', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        table: {
+          table_name: 'subquery2',
+          access_type: 'ALL',
+          rows_examined_per_scan: 50,
+          cost_info: { query_cost: '5.00' },
+          used_columns: ['col1'],
+          materialized_from_subquery: {
+            query_block: {
+              select_id: 2,
+              table: {
+                table_name: 'raw_data',
+                access_type: 'ALL',
+                rows_examined_per_scan: 500,
+                cost_info: { query_cost: '50.00' },
+                used_columns: ['col1'],
+              },
+            },
+          },
+        },
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('ALL')
+    expect(n.relation).toBe('raw_data')
+    expect(n.rows).toBe(500)
+  })
+
+  it('returns empty array for empty result', () => {
+    const nodes = parseMySqlJson({})
+    expect(nodes).toEqual([])
+  })
+
+  it('handles const access type', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        table: {
+          table_name: 'constants',
+          access_type: 'const',
+          rows_examined_per_scan: 1,
+          cost_info: { query_cost: '0.50' },
+          used_columns: ['value'],
+        },
+      },
+    })
+    const nodes = parseMySqlJson(JSON.parse(raw))
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].nodeType).toBe('const')
+    expect(nodes[0].relation).toBe('constants')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SQLite text parser tests
+// ---------------------------------------------------------------------------
+
+describe('parseSqliteText', () => {
+  it('parses a simple SCAN TABLE', () => {
+    const text = `4|0|0|SCAN TABLE users`
+    const nodes = parseSqliteText(text)
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('SCAN TABLE')
+    expect(n.relation).toBe('users')
+  })
+
+  it('parses SEARCH TABLE using index', () => {
+    const text = `2|0|0|SEARCH TABLE orders USING INDEX idx_orders_user (user_id=?)`
+    const nodes = parseSqliteText(text)
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('SEARCH TABLE')
+    expect(n.relation).toBe('orders')
+    expect(n.index).toBe('idx_orders_user')
+  })
+
+  it('parses a two-table join', () => {
+    const text = `1|0|0|SCAN TABLE users
+4|1|0|SEARCH TABLE orders USING INDEX idx_orders_user (user_id=?)`
+    const nodes = parseSqliteText(text)
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].nodeType).toBe('SCAN TABLE')
+    expect(nodes[0].relation).toBe('users')
+    expect(nodes[0].children).toHaveLength(1)
+    expect(nodes[0].children[0].nodeType).toBe('SEARCH TABLE')
+    expect(nodes[0].children[0].relation).toBe('orders')
+    expect(nodes[0].children[0].index).toBe('idx_orders_user')
+  })
+
+  it('parses a subquery plan', () => {
+    const text = `1|0|0|SCAN TABLE users
+2|1|1|SCAN TABLE orders
+3|0|0|USE TEMP B-TREE FOR ORDER BY`
+    const nodes = parseSqliteText(text)
+    expect(nodes).toHaveLength(2)
+    // id=1 is root with id=2 as child, id=3 is separate root
+    const btree = nodes.find(n => n.nodeType === 'USE TEMP B-TREE FOR ORDER BY')
+    expect(btree).toBeDefined()
+  })
+
+  it('parses ORDER BY using temp B-tree', () => {
+    const text = `3|0|0|USE TEMP B-TREE FOR ORDER BY`
+    const nodes = parseSqliteText(text)
+    expect(nodes).toHaveLength(1)
+    const n = nodes[0]
+    expect(n.nodeType).toBe('USE TEMP B-TREE FOR ORDER BY')
+    expect(n.details[0]).toBe('USE TEMP B-TREE FOR ORDER BY')
+  })
+
+  it('returns empty array for empty string', () => {
+    const nodes = parseSqliteText('')
+    expect(nodes).toEqual([])
+  })
+
+  it('parses a multi-level subquery tree', () => {
+    const text = `1|0|0|SCAN TABLE parent
+2|1|0|SEARCH TABLE child USING INDEX idx_child_parent (parent_id=?)
+3|2|0|SEARCH TABLE grandchild USING INDEX idx_grandchild_child (child_id=?)`
+    const nodes = parseSqliteText(text)
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].nodeType).toBe('SCAN TABLE')
+    expect(nodes[0].relation).toBe('parent')
+    expect(nodes[0].children).toHaveLength(1)
+    expect(nodes[0].children[0].relation).toBe('child')
+    expect(nodes[0].children[0].children).toHaveLength(1)
+    expect(nodes[0].children[0].children[0].relation).toBe('grandchild')
+  })
+
+  it('parses a CORRELATED SCALAR SUBQUERY', () => {
+    const text = `5|0|0|EXECUTE CORRELATED SCALAR SUBQUERY 4`
+    const nodes = parseSqliteText(text)
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].nodeType).toBe('EXECUTE CORRELATED SCALAR SUBQUERY')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SQL Server text parser tests
+// ---------------------------------------------------------------------------
+
+describe('parseSqlServerText', () => {
+  it('parses a simple SELECT', () => {
+    const text = `SELECT * FROM users
+  |--Table Scan(OBJECT:([users]))`
+    const nodes = parseSqlServerText(text)
+    expect(nodes.length).toBeGreaterThan(0)
+    const tableScan = nodes.find(n => n.nodeType === 'Table Scan')
+    expect(tableScan).toBeDefined()
+    expect(tableScan!.relation).toBe('users')
+  })
+
+  it('parses a JOIN with hash match', () => {
+    const text = `SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id
+  |--Hash Match(Inner Join, HASH:([o].[customer_id])=([c].[id]))
+      |--Table Scan(OBJECT:([orders]))
+      |--Table Scan(OBJECT:([customers]))`
+    const nodes = parseSqlServerText(text)
+    expect(nodes.length).toBeGreaterThan(0)
+    const hashMatch = nodes.find(n => n.nodeType === 'Hash Match')
+    expect(hashMatch).toBeDefined()
+    expect(hashMatch!.details[0]).toContain('Inner Join')
+  })
+
+  it('parses an Index Seek', () => {
+    const text = `SELECT id FROM products WHERE category = 5
+  |--Index Seek(OBJECT:([products].[idx_products_category]), SEEK:([category]=5))`
+    const nodes = parseSqlServerText(text)
+    expect(nodes.length).toBeGreaterThan(0)
+    const idxSeek = nodes.find(n => n.nodeType === 'Index Seek')
+    expect(idxSeek).toBeDefined()
+    expect(idxSeek!.relation).toBe('products')
+    expect(idxSeek!.index).toBe('idx_products_category')
+  })
+
+  it('parses Sort + Compute Scalar', () => {
+    const text = `SELECT name FROM users ORDER BY name
+  |--Sort(ORDER BY:([name] ASC))
+      |--Compute Scalar(DEFINE:([name]=[users].[name]))
+          |--Table Scan(OBJECT:([users]))`
+    const nodes = parseSqlServerText(text)
+    expect(nodes.length).toBeGreaterThan(0)
+    const sort = nodes.find(n => n.nodeType === 'Sort')
+    expect(sort).toBeDefined()
+    const compute = nodes.find(n => n.nodeType === 'Compute Scalar')
+    expect(compute).toBeDefined()
+    const tableScan = nodes.find(n => n.nodeType === 'Table Scan' && n.relation === 'users')
+    expect(tableScan).toBeDefined()
+  })
+
+  it('parses empty string', () => {
+    const nodes = parseSqlServerText('')
+    expect(nodes).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Generic text parser tests (DuckDB / ClickHouse)
+// ---------------------------------------------------------------------------
+
+describe('parseGenericText', () => {
+  it('parses DuckDB-style explain output', () => {
+    const text = `┌─────────────────────────────┐
+│         PROJECTION         │
+│    ────────────────────    │
+│          ~2 Rows           │
+│      ──── ──── ────        │
+│            #0              │
+│          count_star()      │
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│         HASH_GROUP_BY      │
+│         ────────────       │
+│          Groups: #0        │
+│          ~2 Rows           │
+├─────────────────────────────┤
+│          AGGREGATE         │
+│         ────────────       │
+│          ~2 Rows           │
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│          SEQ_SCAN           │
+│         ────────────        │
+│           Table: users      │
+│           ~2 Rows           │
+└─────────────────────────────┘`
+    const nodes = parseGenericText(text)
+    // Each non-empty line becomes a node, but we deduplicate by trimming
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('parses ClickHouse-style explain output', () => {
+    const text = `EXPLAIN SELECT * FROM users
+  Union
+  .....
+  Expression
+  ....
+  ReadFromStorage (Read from MergeTree)`
+    const nodes = parseGenericText(text)
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('returns empty array for empty string', () => {
+    const nodes = parseGenericText('')
+    expect(nodes).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helper function tests
+// ---------------------------------------------------------------------------
+
+describe('getCostColor', () => {
+  it('returns green for cost < 10%', () => {
+    expect(getCostColor(5, 100)).toBe('green')
+    expect(getCostColor(0, 100)).toBe('green')
+    expect(getCostColor(9, 100)).toBe('green')
+  })
+
+  it('returns yellow for cost between 10% and 40%', () => {
+    expect(getCostColor(10, 100)).toBe('yellow')
+    expect(getCostColor(25, 100)).toBe('yellow')
+    expect(getCostColor(39, 100)).toBe('yellow')
+  })
+
+  it('returns red for cost >= 40%', () => {
+    expect(getCostColor(40, 100)).toBe('red')
+    expect(getCostColor(75, 100)).toBe('red')
+    expect(getCostColor(100, 100)).toBe('red')
+  })
+
+  it('returns green when totalCost <= 0', () => {
+    expect(getCostColor(99, 0)).toBe('green')
+    expect(getCostColor(99, -1)).toBe('green')
+  })
+})
+
+describe('findMostExpensiveNode', () => {
+  it('finds the node with highest totalCost', () => {
+    const nodes: ExplainPlanNode[] = [
+      {
+        id: '1',
+        title: 'Seq Scan',
+        nodeType: 'Seq Scan',
+        details: [],
+        children: [],
+        totalCost: 10,
+      },
+      {
+        id: '2',
+        title: 'Index Scan',
+        nodeType: 'Index Scan',
+        details: [],
+        children: [],
+        totalCost: 50,
+      },
+      {
+        id: '3',
+        title: 'Sort',
+        nodeType: 'Sort',
+        details: [],
+        children: [],
+        totalCost: 25,
+      },
+    ]
+    expect(findMostExpensiveNode(nodes)).toBe('Index Scan')
+  })
+
+  it('returns undefined for empty array', () => {
+    expect(findMostExpensiveNode([])).toBeUndefined()
+  })
+
+  it('ignores nodes without totalCost', () => {
+    const nodes: ExplainPlanNode[] = [
+      { id: '1', title: 'Result', nodeType: 'Result', details: [], children: [] },
+    ]
+    expect(findMostExpensiveNode(nodes)).toBeUndefined()
+  })
+})
+
+describe('calculateTotalCost', () => {
+  it('sums totalCost of all root nodes', () => {
+    const nodes: ExplainPlanNode[] = [
+      { id: '1', title: 'A', nodeType: 'A', totalCost: 10, details: [], children: [] },
+      { id: '2', title: 'B', nodeType: 'B', totalCost: 20, details: [], children: [] },
+      { id: '3', title: 'C', nodeType: 'C', totalCost: 30, details: [], children: [] },
+    ]
+    expect(calculateTotalCost(nodes)).toBe(60)
+  })
+
+  it('returns 0 for empty array', () => {
+    expect(calculateTotalCost([])).toBe(0)
+  })
+
+  it('skips nodes without totalCost', () => {
+    const nodes: ExplainPlanNode[] = [
+      { id: '1', title: 'A', nodeType: 'A', totalCost: 10, details: [], children: [] },
+      { id: '2', title: 'B', nodeType: 'B', details: [], children: [] },
+    ]
+    expect(calculateTotalCost(nodes)).toBe(10)
+  })
+})
+
+describe('flattenNodes', () => {
+  it('flattens a tree structure into an array', () => {
+    const leaf1: ExplainPlanNode = { id: '1.0', title: 'Leaf1', nodeType: 'Scan', details: [], children: [] }
+    const leaf2: ExplainPlanNode = { id: '1.1', title: 'Leaf2', nodeType: 'Index', details: [], children: [] }
+    const parent: ExplainPlanNode = {
+      id: '1',
+      title: 'Join',
+      nodeType: 'Join',
+      details: [],
+      children: [leaf1, leaf2],
+    }
+    const flat = flattenNodes([parent])
+    expect(flat).toHaveLength(3)
+    expect(flat[0].id).toBe('1')
+    expect(flat[1].id).toBe('1.0')
+    expect(flat[2].id).toBe('1.1')
+  })
+
+  it('handles empty array', () => {
+    expect(flattenNodes([])).toEqual([])
+  })
+
+  it('flattens deeply nested trees', () => {
+    const leaf: ExplainPlanNode = { id: '0.0.0', title: 'Deep Leaf', nodeType: 'Scan', details: [], children: [] }
+    const mid: ExplainPlanNode = { id: '0.0', title: 'Mid', nodeType: 'Join', details: [], children: [leaf] }
+    const root: ExplainPlanNode = { id: '0', title: 'Root', nodeType: 'Sort', details: [], children: [mid] }
+    const flat = flattenNodes([root])
+    expect(flat).toHaveLength(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseExplainResult integration tests
+// ---------------------------------------------------------------------------
+
+describe('parseExplainResult', () => {
+  it('dispatches to PostgreSQL JSON parser when databaseType is postgresql and format is json', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Seq Scan',
+          'Relation Name': 'users',
+          'Startup Cost': 0.00,
+          'Total Cost': 35.50,
+          'Plan Rows': 250,
+          'Plan Width': 36,
+        },
+      },
+    ])
+    const result = parseExplainResult(raw, 'postgresql', 'json', false)
+    expect(result.databaseType).toBe('postgresql')
+    expect(result.format).toBe('json')
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].nodeType).toBe('Seq Scan')
+  })
+
+  it('dispatches to MySQL JSON parser when databaseType is mysql and format is json', () => {
+    const raw = JSON.stringify({
+      query_block: {
+        select_id: 1,
+        table: {
+          table_name: 'users',
+          access_type: 'ALL',
+          rows_examined_per_scan: 100,
+          cost_info: { query_cost: '10.00' },
+          used_columns: ['id'],
+        },
+      },
+    })
+    const result = parseExplainResult(raw, 'mysql', 'json', false)
+    expect(result.databaseType).toBe('mysql')
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].nodeType).toBe('ALL')
+  })
+
+  it('dispatches to SQLite text parser when databaseType is sqlite', () => {
+    const raw = `4|0|0|SCAN TABLE users`
+    const result = parseExplainResult(raw, 'sqlite', 'text', false)
+    expect(result.databaseType).toBe('sqlite')
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].nodeType).toBe('SCAN TABLE')
+    expect(result.totalCost).toBe(0)
+    expect(result.mostExpensiveNode).toBeUndefined()
+  })
+
+  it('dispatches to SQL Server text parser when databaseType is sqlserver', () => {
+    const raw = `SELECT * FROM users
+  |--Table Scan(OBJECT:([users]))`
+    const result = parseExplainResult(raw, 'sqlserver', 'text', false)
+    expect(result.databaseType).toBe('sqlserver')
+    expect(result.nodes.length).toBeGreaterThan(0)
+  })
+
+  it('dispatches to generic text parser for DuckDB', () => {
+    const raw = `┌─────────────┐
+│  SEQ_SCAN   │
+└─────────────┘`
+    const result = parseExplainResult(raw, 'duckdb', 'text', false)
+    expect(result.databaseType).toBe('duckdb')
+    expect(result.nodes.length).toBeGreaterThan(0)
+  })
+
+  it('dispatches to generic text parser for ClickHouse', () => {
+    const raw = `Expression
+ReadFromStorage`
+    const result = parseExplainResult(raw, 'clickhouse', 'text', false)
+    expect(result.databaseType).toBe('clickhouse')
+    expect(result.nodes.length).toBeGreaterThan(0)
+  })
+
+  it('sets analyze flag correctly', () => {
+    const raw = JSON.stringify([
+      {
+        Plan: {
+          'Node Type': 'Seq Scan',
+          'Relation Name': 'users',
+          'Startup Cost': 0.00,
+          'Total Cost': 35.50,
+          'Plan Rows': 250,
+          'Plan Width': 36,
+        },
+      },
+    ])
+    const result = parseExplainResult(raw, 'postgresql', 'json', true)
+    expect(result.analyze).toBe(true)
+  })
+
+  it('preserves raw output', () => {
+    const raw = `4|0|0|SCAN TABLE users`
+    const result = parseExplainResult(raw, 'sqlite', 'text', false)
+    expect(result.raw).toBe(raw)
+  })
+
+  describe('parseMySqlAnalyzeText', () => {
+    it('parses a simple table scan', () => {
+      const text = `-> Table scan on users  (cost=0.5 rows=2)`
+      const nodes = parseMySqlAnalyzeText(text)
+      expect(nodes).toHaveLength(1)
+      expect(nodes[0].nodeType).toBe('Table scan')
+      expect(nodes[0].relation).toBe('users')
+      expect(nodes[0].totalCost).toBe(0.5)
+      expect(nodes[0].rows).toBe(2)
+    })
+
+    it('parses a nested loop join with two children', () => {
+      const text = [
+        '-> Nested loop inner join  (cost=1.0 rows=1)',
+        '    -> Table scan on users  (cost=0.5 rows=2)',
+        '    -> Index lookup on orders using user_id  (cost=0.5 rows=1)',
+      ].join('\n')
+      const nodes = parseMySqlAnalyzeText(text)
+      expect(nodes).toHaveLength(1)
+      expect(nodes[0].nodeType).toBe('Nested loop inner join')
+      expect(nodes[0].children).toHaveLength(2)
+      expect(nodes[0].children[0].nodeType).toBe('Table scan')
+      expect(nodes[0].children[0].relation).toBe('users')
+      expect(nodes[0].children[1].relation).toBe('orders')
+    })
+
+    it('parses deeply nested plans', () => {
+      const text = [
+        '-> Nested loop inner join  (cost=2.0 rows=1)',
+        '    -> Table scan on users  (cost=0.5 rows=2)',
+        '    -> Nested loop inner join  (cost=1.5 rows=1)',
+        '        -> Index lookup on orders  (cost=0.5 rows=1)',
+        '        -> Index lookup on payments  (cost=0.5 rows=1)',
+      ].join('\n')
+      const nodes = parseMySqlAnalyzeText(text)
+      expect(nodes).toHaveLength(1)
+      expect(nodes[0].children).toHaveLength(2)
+      expect(nodes[0].children[1].nodeType).toBe('Nested loop inner join')
+      expect(nodes[0].children[1].children).toHaveLength(2)
+    })
+
+    it('returns empty array for empty input', () => {
+      expect(parseMySqlAnalyzeText('')).toEqual([])
+    })
+
+    it('returns empty array when no -> lines', () => {
+      expect(parseMySqlAnalyzeText('some random text')).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements a visual query execution plan feature (#68) inspired by DBX's implementation. Displays EXPLAIN output as an interactive tree with cost-based color coding, supporting PostgreSQL, MySQL, SQLite, SQL Server, DuckDB, and ClickHouse.

### Backend Changes

- **New  struct** in  — returned by the explain_query command with database_type, raw output, format (json/text), and analyze flag
- **Reworked  command** — per-database EXPLAIN SQL generation:
  - PostgreSQL: `EXPLAIN (ANALYZE, FORMAT JSON)`
  - MySQL: `EXPLAIN FORMAT=JSON` / `EXPLAIN ANALYZE` (TREE text)
  - SQLite: `EXPLAIN QUERY PLAN`
  - SQL Server: `SET SHOWPLAN_TEXT ON` / `SET STATISTICS PROFILE ON` with proper cleanup
  - DuckDB: `EXPLAIN` / `EXPLAIN ANALYZE`
  - Added `analyze` parameter for EXPLAIN ANALYZE toggle
  - SQL Server StmtText column extraction for multi-column STATISTICS PROFILE output

### Frontend Changes

- **Types**: `ExplainPlanNode` and `ExplainResult` interfaces
- **Parsers** (in `src/utils/explainPlanParser.ts`):
  - PostgreSQL JSON recursive tree parser
  - MySQL JSON parser with synthetic join parent nodes
  - MySQL EXPLAIN ANALYZE TREE-format parser (indentation-based)
  - SQLite pipe-delimited tree builder
  - SQL Server SHOWPLAN text parser
  - DuckDB/ClickHouse generic fallback parser
  - Cost coloring helper (`getCostColor`: green <10%, yellow 10-40%, red >=40%)
  - Recursive `calculateTotalCost`, `findMostExpensiveNode`, `flattenNodes`
- **Components** (in `src/components/explain-plan/`):
  - `ExplainPlanPanel` — container with summary bar + Tree/Summary/Raw view tabs
  - `ExplainPlanNodeTree` — recursive tree with cost-colored dots, expand/collapse, actual vs estimated rows, hover tooltips
  - `ExplainPlanSummaryTable` — flat depth-indented table
  - `ExplainPlanRawView` — formatted JSON/text display
- **Integration**:
  - `tabStore`: `explainPlan`/explainError`/isExplaining` state + `explainQuery()` action + persist serializer strips session state
  - `QueryResultPanel`: Results/Explain tab bar
  - `QueriesPage`: working Explain button, ANALYZE toggle (green A button), F6 shortcut
- **i18n**: Full English and Chinese translations for all UI text
- **Tests**: 63 test cases in `tests/explainPlanParser.test.ts`

### Design Decisions

- **Frontend-only parsing**: Backend returns raw EXPLAIN output, frontend builds the tree — keeps Rust backend simple
- **Format detection per connection arm**: MySQL EXPLAIN ANALYZE returns TREE text (not JSON), so format is set dynamically per database arm instead of a global flag
- **Cost coloring**: Green dot < 10% of total cost, Yellow 10-40%, Red >= 40%
- **Tab persistence stripped**: `explainPlan` data excluded from localStorage serialization to avoid size issues

Closes #68