### PR TITLE
feat(jre): prefer managed JRE, validate bridge JAR, capture stderr

### DIFF
--- a/jdbc-bridge/pom.xml
+++ b/jdbc-bridge/pom.xml
@@ -84,6 +84,9 @@
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>sqlkit.bridge.BridgeMain</mainClass>
+                            <manifestEntries>
+                                <Implementation-Version>${revision}</Implementation-Version>
+                            </manifestEntries>
                         </transformer>
                     </transformers>
                 </configuration>

--- a/jdbc-bridge/src/main/java/sqlkit/bridge/BridgeMain.java
+++ b/jdbc-bridge/src/main/java/sqlkit/bridge/BridgeMain.java
@@ -18,6 +18,13 @@ public class BridgeMain {
     private static final ProtocolHandler HANDLER = new ProtocolHandler(new ConnectionManager());
 
     public static void main(String[] args) throws Exception {
+        if (args.length > 0 && "--version".equals(args[0])) {
+            String ver = BridgeMain.class.getPackage().getImplementationVersion();
+            System.out.println(ver != null ? ver : "unknown");
+            System.out.flush();
+            return;
+        }
+
         // Disable Jackson's FAIL_ON_EMPTY_BEANS for safety
         MAPPER.disable(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,25 @@
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    let content = std::fs::read_to_string("../package.json")
+        .expect("package.json not found — build script depends on it");
+    let version = content
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("\"version\"") {
+                trimmed
+                    .split(':')
+                    .nth(1)?
+                    .trim()
+                    .trim_matches(|c| c == ',' || c == '"' || c == ' ')
+                    .to_string()
+                    .into()
+            } else {
+                None
+            }
+        })
+        .expect("version field not found in package.json");
+    println!("cargo:rustc-env=APP_VERSION={}", version);
+    println!("cargo:rerun-if-changed=../package.json");
 }

--- a/src-tauri/src/commands/jdbc.rs
+++ b/src-tauri/src/commands/jdbc.rs
@@ -28,14 +28,17 @@ pub async fn check_jre_status() -> Result<JreStatus, String> {
     if managed_path.exists() {
         Ok(JreStatus {
             installed: true,
-            version: jre::read_jre_version().or_else(|| Some("21".to_string())),
+            version: jre::read_jre_version().or_else(|| Some("25".to_string())),
             path: Some(managed_path.to_string_lossy().to_string()),
             source: "managed".to_string(),
         })
     } else if let Some(system_java) = jre::JreDetector::detect_system_java() {
+        let version = jre::system_java_version(&system_java)
+            .map(|v| format!("{}.x", v))
+            .or_else(|| Some("system".to_string()));
         Ok(JreStatus {
             installed: true,
-            version: Some("system".to_string()),
+            version,
             path: Some(system_java.to_string_lossy().to_string()),
             source: "system".to_string(),
         })
@@ -214,10 +217,10 @@ pub async fn check_bridge_status() -> Result<BridgeStatus, String> {
             .file_stem()
             .and_then(|s| s.to_str())
             .and_then(|s| s.strip_prefix("jdbc-bridge-"))
-            .unwrap_or(env!("CARGO_PKG_VERSION"))
+            .unwrap_or(env!("APP_VERSION"))
             .to_string()
     } else {
-        env!("CARGO_PKG_VERSION").to_string()
+        env!("APP_VERSION").to_string()
     };
     Ok(BridgeStatus {
         installed: jar_path.exists(),

--- a/src-tauri/src/database/jdbc_bridge/download.rs
+++ b/src-tauri/src/database/jdbc_bridge/download.rs
@@ -7,9 +7,9 @@
 
 use crate::database::error::{DbError, DbResult};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
-/// Current app version, used for bridge JAR version pinning.
-const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+const APP_VERSION: &str = env!("APP_VERSION");
 
 /// Subdirectory under user home for bridge data.
 const BRIDGE_DIR: &str = ".sqlkit/jdbc-bridge";
@@ -41,6 +41,13 @@ pub async fn download_to_path(url: &str, dest: &Path) -> DbResult<()> {
     let response = reqwest::get(url)
         .await
         .map_err(|e| DbError::Connection(format!("Failed to download from {}: {}", url, e)))?;
+    if !response.status().is_success() {
+        return Err(DbError::Connection(format!(
+            "Download failed: HTTP {} from {}",
+            response.status(),
+            url
+        )));
+    }
     let bytes = response
         .bytes()
         .await
@@ -60,6 +67,13 @@ pub async fn download_to_path(url: &str, dest: &Path) -> DbResult<()> {
 }
 
 /// Download the bridge fat JAR from GitHub Releases (version-pinned).
+///
+/// Validates the downloaded JAR by checking:
+/// 1. HTTP 200 response status
+/// 2. File size ≥ 1 MB (a fat JAR with dependencies)
+/// 3. `java -jar jdbc-bridge.jar --version` exits 0 (if a JRE is available)
+///
+/// Retries once on validation failure.
 pub async fn download_bridge_plugin() -> DbResult<()> {
     let jar_path = bridge_jar_path();
 
@@ -73,7 +87,67 @@ pub async fn download_bridge_plugin() -> DbResult<()> {
         "https://github.com/geek-fun/sqlkit/releases/download/v{}/jdbc-bridge-{}.jar",
         APP_VERSION, APP_VERSION
     );
-    download_to_path(&url, &jar_path).await?;
+
+    let mut last_err = None::<String>;
+    for _attempt in 0..2 {
+        if let Err(e) = download_to_path(&url, &jar_path).await {
+            last_err = Some(e.to_string());
+            continue;
+        }
+
+        let meta = std::fs::metadata(&jar_path).map_err(|e| {
+            DbError::Connection(format!("Failed to check JAR file size: {}", e))
+        })?;
+        if meta.len() < 1_000_000 {
+            let _ = std::fs::remove_file(&jar_path);
+            last_err = Some(format!(
+                "JAR file too small ({} bytes, expected ≥ 1 MB)",
+                meta.len()
+            ));
+            continue;
+        }
+
+        if let Some(java) = super::jre::JreDetector::detect() {
+            let output = Command::new(&java)
+                .args(["-jar", &jar_path.to_string_lossy(), "--version"])
+                .output()
+                .map_err(|e| {
+                    DbError::Connection(format!("Failed to run JAR validation: {}", e))
+                })?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let _ = std::fs::remove_file(&jar_path);
+                last_err = Some(format!(
+                    "Bridge JAR validation failed (exit: {}): {}",
+                    output.status, stderr
+                ));
+                continue;
+            }
+
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if stdout.is_empty() || stdout == "unknown" {
+                let _ = std::fs::remove_file(&jar_path);
+                last_err = Some(format!(
+                    "Bridge JAR --version returned invalid output: {}",
+                    stdout
+                ));
+                continue;
+            }
+        }
+
+        last_err = None;
+        break;
+    }
+
+    if let Some(err) = last_err {
+        let tmp_path = jar_path.with_extension("tmp");
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(DbError::Connection(format!(
+            "Failed to download valid bridge JAR after retry: {}",
+            err
+        )));
+    }
 
     cleanup_old_bridge_versions().await?;
 

--- a/src-tauri/src/database/jdbc_bridge/fallback.rs
+++ b/src-tauri/src/database/jdbc_bridge/fallback.rs
@@ -189,18 +189,43 @@ pub async fn run_fallback_chain(
         DbError::Connection(format!("No driver registry entry for {:?}", db_type))
     })?;
 
-    // Ensure JRE is installed.
-    if super::jre::JreDetector::detect().is_none() {
-        super::jre::download_managed_jre().await?;
+    if !super::jre::is_managed_jre_installed() {
+        if let Err(download_err) = super::jre::download_managed_jre().await {
+            match super::jre::JreDetector::detect_system_java() {
+                Some(system_path) => match super::jre::system_java_version(&system_path) {
+                    Some(version) if version >= 25 => {}
+                    Some(version) => {
+                        return Err(DbError::Connection(format!(
+                            "System Java version is {} but Java 25+ is required. \
+                             SQLKit could not download a managed JRE: {}. \
+                             Install Java 25 manually or retry with internet access.",
+                            version, download_err
+                        )));
+                    }
+                    None => {
+                        return Err(DbError::Connection(format!(
+                            "Could not determine system Java version. \
+                             SQLKit could not download a managed JRE: {}. \
+                             Install Java 25 manually or retry with internet access.",
+                            download_err
+                        )));
+                    }
+                },
+                None => {
+                    return Err(DbError::Connection(format!(
+                        "No Java 25+ found. SQLKit could not download a managed JRE: {}. \
+                         Check your internet connection or install Java 25 manually.",
+                        download_err
+                    )));
+                }
+            }
+        }
     } else {
-        // Check for JRE update on connection if managed JRE is installed.
-        if super::jre::is_managed_jre_installed() {
-            if let Some(redirect_url) = super::jre::check_adoptium_update().await {
-                if let Some(latest) = super::jre::parse_adoptium_build_version(&redirect_url) {
-                    if let Some(current) = super::jre::read_jre_version() {
-                        if super::jre::compare_versions(&latest, &current) > 0 {
-                            super::jre::download_managed_jre().await?;
-                        }
+        if let Some(redirect_url) = super::jre::check_adoptium_update().await {
+            if let Some(latest) = super::jre::parse_adoptium_build_version(&redirect_url) {
+                if let Some(current) = super::jre::read_jre_version() {
+                    if super::jre::compare_versions(&latest, &current) > 0 {
+                        super::jre::download_managed_jre().await?;
                     }
                 }
             }

--- a/src-tauri/src/database/jdbc_bridge/jre.rs
+++ b/src-tauri/src/database/jdbc_bridge/jre.rs
@@ -1,6 +1,6 @@
 //! Managed JRE detection, download, and lifecycle.
 //!
-//! SQLKit downloads a JRE 25 (latest LTS) from Adoptium (Eclipse Temurin) for each supported
+//! SQLKit downloads a JRE 25 (latest stable) from Adoptium (Eclipse Temurin) for each supported
 //! platform. This module handles detecting Java (managed → `JAVA_HOME` → `PATH`),
 //! downloading/extracting the managed JRE, version checking via the built-in
 //! `release` file, and cleaning it up.
@@ -136,6 +136,35 @@ impl JreDetector {
 
 // ── version reading ───────────────────────────────────────
 
+/// Determine the major Java version by running `java -version`.
+///
+/// Handles both pre-Java-9 format (`1.8.0_431` → 8), Java-9+ format
+/// (`25.0.1` → 25), and pre-release builds (`25-ea` → 25). Falls back to
+/// stdout if stderr is empty (some alternative JDK builds output version
+/// there). Returns `None` if the path doesn't exist, isn't a Java binary,
+/// or the version string can't be parsed.
+pub fn system_java_version(java: &PathBuf) -> Option<u32> {
+    let output = std::process::Command::new(java).arg("-version").output().ok()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let version_str = stderr
+        .lines()
+        .chain(stdout.lines())
+        .find(|l| l.contains("version"))
+        .and_then(|l| l.split('"').nth(1))?;
+    let parts: Vec<&str> = version_str.split('.').collect();
+    if parts.is_empty() {
+        return None;
+    }
+    let major_str = parts[0].trim_end_matches(|c: char| !c.is_ascii_digit());
+    let major = major_str.parse::<u32>().ok()?;
+    if major == 1 && parts.len() >= 2 {
+        parts[1].parse::<u32>().ok() // Java 8: "1.8.0_431" → 8
+    } else {
+        Some(major) // Java 9+: "25.0.1" → 25, "25-ea" → 25
+    }
+}
+
 /// Read the JRE version from the built-in `release` file.
 ///
 /// The release file is a Java properties file that ships with every OpenJDK build
@@ -208,7 +237,7 @@ pub fn parse_adoptium_build_version(url: &str) -> Option<String> {
 
 /// Download and extract the managed JRE for the current platform from Adoptium.
 ///
-/// Downloads the latest JRE 21 (Eclipse Temurin) build from the Adoptium API,
+/// Downloads the latest JRE 25 (Eclipse Temurin) build from the Adoptium API,
 /// extracts the archive, and renames the extracted directory to `jre`.
 pub async fn download_managed_jre() -> DbResult<()> {
     let _guard = JRE_INSTALL_LOCK
@@ -416,5 +445,12 @@ mod tests {
             parse_adoptium_build_version("https://example.com/hotspot_"),
             None
         );
+    }
+
+    #[test]
+    fn test_system_java_version_not_java() {
+        // A non-Java binary should return None.
+        let current = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("/"));
+        assert!(system_java_version(&current).is_none());
     }
 }

--- a/src-tauri/src/database/jdbc_bridge/launcher.rs
+++ b/src-tauri/src/database/jdbc_bridge/launcher.rs
@@ -7,6 +7,8 @@ use crate::database::error::{DbError, DbResult};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread;
 
 use super::protocol::{JdbcRequest, JdbcResponse};
 
@@ -15,6 +17,9 @@ pub struct JdbcBridgeLauncher {
     process: Option<Child>,
     stdin: Option<ChildStdin>,
     jar_path: PathBuf,
+    /// Buffered stderr lines from the Java bridge, drained by a background
+    /// reader thread to prevent the OS pipe buffer from filling up.
+    stderr_buffer: Option<Arc<Mutex<Vec<String>>>>,
 }
 
 impl JdbcBridgeLauncher {
@@ -24,6 +29,7 @@ impl JdbcBridgeLauncher {
             process: None,
             stdin: None,
             jar_path,
+            stderr_buffer: None,
         }
     }
 
@@ -32,7 +38,41 @@ impl JdbcBridgeLauncher {
         super::jre::JreDetector::detect()
     }
 
-    /// Start the Java bridge process.
+    fn read_stderr_buffer(buf: &Arc<Mutex<Vec<String>>>) -> String {
+        buf.lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .join("\n")
+    }
+
+    fn drain_stderr(&self) -> String {
+        self.stderr_buffer
+            .as_ref()
+            .map(|buf| Self::read_stderr_buffer(buf))
+            .unwrap_or_default()
+    }
+
+    fn spawn_stderr_reader(stderr: std::process::ChildStderr) -> Arc<Mutex<Vec<String>>> {
+        let buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let buf_clone = buf.clone();
+        thread::spawn(move || {
+            let mut reader = BufReader::new(stderr);
+            let mut line = String::new();
+            while reader.read_line(&mut line).is_ok() && !line.is_empty() {
+                let trimmed = line.trim().to_string();
+                if !trimmed.is_empty() {
+                    if let Ok(mut b) = buf_clone.lock() {
+                        b.push(trimmed);
+                        if b.len() > 200 {
+                            b.remove(0);
+                        }
+                    }
+                }
+                line.clear();
+            }
+        });
+        buf
+    }
+
     pub fn start(&mut self) -> DbResult<()> {
         let java = Self::detect_java().ok_or_else(|| {
             DbError::Connection(
@@ -41,18 +81,11 @@ impl JdbcBridgeLauncher {
             )
         })?;
 
-        if !self.jar_path.exists() {
-            return Err(DbError::Connection(format!(
-                "JDBC bridge JAR not found at {}. Run download_bridge_plugin() first.",
-                self.jar_path.display()
-            )));
-        }
-
         let mut child = Command::new(&java)
             .args(["-jar", self.jar_path.to_str().unwrap_or("")])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| DbError::Connection(format!("Failed to start JDBC bridge: {}", e)))?;
 
@@ -61,6 +94,8 @@ impl JdbcBridgeLauncher {
             .take()
             .ok_or_else(|| DbError::Connection("Failed to capture bridge stdin".to_string()))?;
 
+        let stderr = child.stderr.take().expect("stderr was piped");
+        self.stderr_buffer = Some(Self::spawn_stderr_reader(stderr));
         self.process = Some(child);
         self.stdin = Some(stdin);
 
@@ -70,8 +105,9 @@ impl JdbcBridgeLauncher {
             match child.try_wait() {
                 Ok(Some(status)) => {
                     return Err(DbError::Connection(format!(
-                        "JDBC bridge exited immediately with code: {}",
-                        status
+                        "JDBC bridge exited immediately with code: {}. stderr: {}",
+                        status,
+                        self.drain_stderr()
                     )));
                 }
                 Ok(None) => { /* still running, good */ }
@@ -96,13 +132,6 @@ impl JdbcBridgeLauncher {
             )
         })?;
 
-        if !self.jar_path.exists() {
-            return Err(DbError::Connection(format!(
-                "JDBC bridge JAR not found at {}. Run download_bridge_plugin() first.",
-                self.jar_path.display()
-            )));
-        }
-
         // Build classpath: bridge JAR + driver JARs
         let mut classpath = self.jar_path.to_string_lossy().to_string();
         for jar in &driver_jars {
@@ -115,7 +144,7 @@ impl JdbcBridgeLauncher {
             .args(["-cp", &classpath, "sqlkit.bridge.BridgeMain"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| DbError::Connection(format!("Failed to start JDBC bridge: {}", e)))?;
 
@@ -124,6 +153,8 @@ impl JdbcBridgeLauncher {
             .take()
             .ok_or_else(|| DbError::Connection("Failed to capture bridge stdin".to_string()))?;
 
+        let stderr = child.stderr.take().expect("stderr was piped");
+        self.stderr_buffer = Some(Self::spawn_stderr_reader(stderr));
         self.process = Some(child);
         self.stdin = Some(stdin);
 
@@ -133,8 +164,9 @@ impl JdbcBridgeLauncher {
             match child.try_wait() {
                 Ok(Some(status)) => {
                     return Err(DbError::Connection(format!(
-                        "JDBC bridge exited immediately with code: {}",
-                        status
+                        "JDBC bridge exited immediately with code: {}. stderr: {}",
+                        status,
+                        self.drain_stderr()
                     )));
                 }
                 Ok(None) => { /* still running, good */ }
@@ -167,27 +199,66 @@ impl JdbcBridgeLauncher {
             .as_mut()
             .ok_or_else(|| DbError::Connection("JDBC bridge stdin not available".to_string()))?;
 
-        // Serialize and write request line
         let json = serde_json::to_string(req)
             .map_err(|e| DbError::Connection(format!("Failed to serialize request: {}", e)))?;
 
-        writeln!(stdin, "{}", json)
-            .map_err(|e| DbError::Connection(format!("Failed to write to bridge stdin: {}", e)))?;
-        stdin
-            .flush()
-            .map_err(|e| DbError::Connection(format!("Failed to flush bridge stdin: {}", e)))?;
+        writeln!(stdin, "{}", json).map_err(|e| {
+            let stderr = self.stderr_buffer.as_ref()
+                .map(Self::read_stderr_buffer)
+                .unwrap_or_default();
+            if stderr.is_empty() {
+                DbError::Connection(format!("Failed to write to bridge stdin: {}", e))
+            } else {
+                DbError::Connection(format!(
+                    "Bridge write error: {}. stderr: {}",
+                    e, stderr
+                ))
+            }
+        })?;
+        stdin.flush().map_err(|e| {
+            let stderr = self.stderr_buffer.as_ref()
+                .map(Self::read_stderr_buffer)
+                .unwrap_or_default();
+            if stderr.is_empty() {
+                DbError::Connection(format!("Failed to flush bridge stdin: {}", e))
+            } else {
+                DbError::Connection(format!(
+                    "Bridge write error: {}. stderr: {}",
+                    e, stderr
+                ))
+            }
+        })?;
 
-        // Read response line
         let mut reader = BufReader::new(stdout);
         let mut line = String::new();
-        reader
-            .read_line(&mut line)
-            .map_err(|e| DbError::Connection(format!("Failed to read bridge response: {}", e)))?;
+        reader.read_line(&mut line).map_err(|e| {
+            let stderr = self.stderr_buffer.as_ref()
+                .map(Self::read_stderr_buffer)
+                .unwrap_or_default();
+            if stderr.is_empty() {
+                DbError::Connection(format!("Failed to read bridge response: {}", e))
+            } else {
+                DbError::Connection(format!(
+                    "Bridge read error: {}. stderr: {}",
+                    e, stderr
+                ))
+            }
+        })?;
 
         if line.trim().is_empty() {
-            return Err(DbError::Connection(
-                "Empty response from JDBC bridge".to_string(),
-            ));
+            let stderr = self.stderr_buffer.as_ref()
+                .map(Self::read_stderr_buffer)
+                .unwrap_or_default();
+            return if stderr.is_empty() {
+                Err(DbError::Connection(
+                    "Empty response from JDBC bridge".to_string(),
+                ))
+            } else {
+                Err(DbError::Connection(format!(
+                    "Bridge read error. stderr: {}",
+                    stderr
+                )))
+            };
         }
 
         let resp: JdbcResponse = serde_json::from_str(line.trim())
@@ -224,6 +295,7 @@ impl JdbcBridgeLauncher {
             let _ = child.wait();
         }
         self.stdin = None;
+        self.stderr_buffer = None;
     }
 }
 

--- a/src-tauri/src/database/jdbc_bridge/mod.rs
+++ b/src-tauri/src/database/jdbc_bridge/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! # Prerequisites
 //!
-//! 1. Java Runtime (JRE 17+) installed on the system
+//! 1. Java Runtime (JRE 25+) installed on the system
 //! 2. `jdbc-bridge.jar` downloaded (via `download_bridge_plugin()`)
 //! 3. JDBC driver JARs for target databases (downloaded automatically)
 


### PR DESCRIPTION
## Summary

The JDBC bridge (used for Oracle, DB2, H2, Derby etc.) had several reliability gaps that caused opaque failures. This PR addresses them:

### Problem 1: Corrupted bridge JAR silently saved to disk

When the bridge JAR download URL returned a 404 (missing asset), the HTML body was saved as `.jar` without validation. The JVM then crashed with an unhelpful `exit status: 1`.

**Fix**: The download pipeline now checks HTTP 200 status, verifies minimum file size (1MB+), and runs `java -jar --version` to confirm the JAR is valid and executable. Failed downloads are retried once; corrupted files are automatically cleaned up.

### Problem 2: Incompatible system JRE used silently

The app detected any `java` binary on `PATH`/JAVA_HOME and used it without checking version. If a user had Java 8 installed, the bridge (compiled for Java 25) would crash with `UnsupportedClassVersionError`.

**Fix**: The managed JRE (downloaded from Adoptium) is now always preferred. The system Java fallback is only used when the download fails **and** the version is ≥ 25. Clear error messages tell the user exactly what's wrong and how to fix it — instead of a cryptic crash code.

### Problem 3: Bridge crash diagnostics invisible

Bridge error logs went to the process stderr, which was inherited by the parent process and never captured. The user only saw `exit status: 1` with no context.

**Fix**: A background reader thread continuously drains stderr into a ring buffer, preventing OS pipe deadlocks. The buffered output is included in all error messages — startup crashes, connection failures, and unexpected exits all show the actual JVM error.

### Problem 4: Version drift between Cargo.toml and package.json

The bridge JAR filename and download URL used `CARGO_PKG_VERSION` (from Cargo.toml), while `tauri.conf.json` and the release tag used `package.json`. These could (and did) drift apart, causing the app to request the wrong asset URL.

**Fix**: `build.rs` now reads `APP_VERSION` from `package.json` at compile time, making it the single source of truth for all version-dependent paths.

### Additional
- Settings page now shows the actual Java version (e.g. `25.x`) instead of just `"system"`
- Stale version references and doc comments updated to reflect current Java 25 requirement