### PR TITLE
feat: add backend SQL construction service and fix query result display

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -153,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,7 +1718,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2001,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2969,7 +2978,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2989,7 +2998,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4213,6 +4222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4939,6 +4957,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4990,7 +5018,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5027,9 +5055,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5140,6 +5168,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -5631,7 +5679,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5732,7 +5780,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6414,6 +6462,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sqlparser",
  "tar",
  "tauri",
  "tauri-build",
@@ -6435,6 +6484,16 @@ dependencies = [
  "url",
  "uuid",
  "zip 2.4.2",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4521174166bac1ff04fe16ef4524c70144cd29682a45978978ca3d7f4e0be11"
+dependencies = [
+ "log",
+ "recursive",
 ]
 
 [[package]]
@@ -6471,6 +6530,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -7111,7 +7183,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8200,7 +8272,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -98,6 +98,7 @@ zip = { version = "2", features = [ "deflate" ] }
 # TOML parsing (drivers.toml)
 toml = "0.8"
 sha2 = "0.10"
+sqlparser = "0.55"
 russh = "0.60"
 portpicker = "0.1.1"
 pageant = "0.2"

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -1030,7 +1030,7 @@ fn extract_count(result: QueryResult) -> Result<u64, String> {
 
 /// Map an [`ActiveConnection`] variant to the db_type string used by
 /// [`quote_identifier`] and [`search::build_table_search_where`].
-fn get_db_type_string(connection: &ActiveConnection) -> &'static str {
+pub fn get_db_type_string(connection: &ActiveConnection) -> &'static str {
     match connection {
         ActiveConnection::Postgres(_) => "postgres",
         ActiveConnection::MySQL(_) => "mysql",

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -6,6 +6,7 @@
 use crate::api_response::{db_error_to_api_error, ApiResponse};
 use crate::connection::guardian::HealthState;
 use crate::connection::handle::ConnectionHandle;
+use crate::database::sql_service::{self, WrapQueryOptions};
 use crate::database::{
     ClickHouseAdapter, ConnectionConfig, DatabaseAdapter, DbError, ExplainResult, HttpSqlAdapter,
     JdbcBridgeAdapter, MySQLAdapter, PostgresAdapter, QueryResult, RqliteAdapter, SqlServerAdapter,
@@ -316,6 +317,49 @@ pub async fn execute_query(
             Ok(ApiResponse::error(api_error))
         }
     }
+}
+
+/// Execute a query with structured sort, filter, and pagination.
+///
+/// Unlike `execute_query` which takes raw SQL, this command takes the user's
+/// original SQL plus structured sort/filter/pagination options and builds the
+/// final SQL on the backend. This prevents SQL injection from filter values
+/// and handles trailing semicolons/comments correctly.
+#[tauri::command]
+pub async fn execute_sorted_query(
+    connection_id: String,
+    database: Option<String>,
+    options: WrapQueryOptions,
+    state: State<'_, AppState>,
+) -> Result<ApiResponse<QueryResult>, String> {
+    // Derive database type from the active connection
+    let db_type = {
+        let connections = state.connections.read().await;
+        let connection = connections
+            .get(&connection_id)
+            .ok_or_else(|| "No active connection found".to_string())?;
+        crate::commands::browse::get_db_type_string(connection).to_string()
+    };
+
+    // Inject the database type into options and build the wrapped SQL
+    let build = sql_service::wrap_query(WrapQueryOptions {
+        database_type: db_type,
+        ..options
+    });
+    if !build.ok {
+        return Ok(ApiResponse::error_from(
+            "SORT_FILTER_ERROR",
+            format!(
+                "Cannot sort/filter: {}",
+                build.reason.unwrap_or_else(|| "unknown error".to_string())
+            ),
+        ));
+    }
+
+    let sql = build.sql.unwrap();
+
+    // Execute via the existing execute_query path
+    crate::commands::execute_query(connection_id, sql, database, state).await
 }
 
 /// Cancel a running query.

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -72,6 +72,7 @@ pub mod pool;
 pub mod postgres;
 pub mod rqlite;
 pub mod search;
+pub mod sql_service;
 pub mod sqlite;
 pub mod sqlserver;
 pub mod strategy;

--- a/src-tauri/src/database/search.rs
+++ b/src-tauri/src/database/search.rs
@@ -124,11 +124,12 @@ fn quote_identifier(identifier: &str, db_type: &str) -> String {
 ///
 /// # Search Behavior
 ///
-/// - **Text columns** (`ColumnCategory::Text`): matched with
-///   `LOWER(CAST(col AS type)) LIKE '%term%'`
-/// - **Numeric columns** (`ColumnCategory::Numeric`): matched with
-///   `(col = term OR LOWER(CAST(col AS type)) LIKE '%term%')` — this handles
-///   both exact numeric matches and text representation matches
+/// - **UUID columns**: matched with `col::text` cast (PostgreSQL-compatible) for
+///   both exact matches and LIKE — avoids the fragile `CAST(col AS TEXT)` pattern
+///   which fails on some PG-compatible engines
+/// - **JSON/JSONB columns**: matched with `col::text` LIKE (avoids CAST)
+/// - **Other text columns**: matched with `LOWER(CAST(col AS type)) LIKE '%term%'`
+/// - **Numeric columns**: matched with both exact equality and text LIKE
 /// - **Skip columns** (`ColumnCategory::Skip`): excluded entirely
 /// - The search is **case-insensitive** via `LOWER()`
 ///
@@ -170,14 +171,43 @@ pub fn build_table_search_where(
         .map(|col| {
             let quoted = quote_identifier(&col.name, db_type);
             let category = classify_column(&col.data_type);
-            let text_condition = format!(
-                "LOWER(CAST({} AS {})) LIKE '%{}%'",
-                quoted, cast_type, lower_term
-            );
+            let data_type = col.data_type.to_lowercase();
 
+            // Type-aware search conditions
             match category {
-                ColumnCategory::Text => text_condition,
+                ColumnCategory::Text => {
+                    if data_type == "uuid" {
+                        // UUID columns: use ::text cast (more portable than CAST)
+                        // For exact UUID matches, also include equality for efficiency
+                        let text_cond = format!(
+                            "LOWER({}::text) LIKE '%{}%'",
+                            quoted, lower_term
+                        );
+                        // If the term looks like a UUID, try exact match first
+                        if looks_like_uuid(&escaped_term) {
+                            format!("{}::text = '{}' OR {}", quoted, escaped_term, text_cond)
+                        } else {
+                            text_cond
+                        }
+                    } else if data_type.starts_with("json") {
+                        // JSON/JSONB: use ::text for readability
+                        format!(
+                            "LOWER({}::text) LIKE '%{}%'",
+                            quoted, lower_term
+                        )
+                    } else {
+                        // Standard text columns
+                        format!(
+                            "LOWER(CAST({} AS {})) LIKE '%{}%'",
+                            quoted, cast_type, lower_term
+                        )
+                    }
+                }
                 ColumnCategory::Numeric => {
+                    let text_condition = format!(
+                        "LOWER(CAST({} AS {})) LIKE '%{}%'",
+                        quoted, cast_type, lower_term
+                    );
                     // Try exact numeric match; if term is a valid number, include equality
                     if term.parse::<f64>().is_ok() {
                         format!("{} = {} OR {}", quoted, term, text_condition)
@@ -196,6 +226,12 @@ pub fn build_table_search_where(
     }
 
     Some(format!("({})", conditions.join(" OR ")))
+}
+
+/// Quick check if a string looks like a UUID (hex with dashes).
+fn looks_like_uuid(s: &str) -> bool {
+    let cleaned: String = s.chars().filter(|c| *c != '-').collect();
+    cleaned.len() == 32 && cleaned.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// Generate a stable WHERE clause that uniquely identifies a row.

--- a/src-tauri/src/database/sql_service.rs
+++ b/src-tauri/src/database/sql_service.rs
@@ -1,0 +1,761 @@
+//! SQL construction service — the single source of truth for building queries.
+//!
+//! All SQL wrapping, validation, filtering, sorting, pagination, and schema
+//! injection goes through this module. The frontend never constructs SQL strings.
+//!
+//! # Design
+//!
+//! Every function returns a `SqlBuildResult` with structured success/failure
+//! so the caller can surface clear error messages instead of cryptic database errors.
+
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::{
+    Expr, Ident, ObjectNamePart, Query, SelectItem, SelectItemQualifiedWildcardKind, SetExpr,
+    Statement, TableFactor, TableWithJoins, Value,
+};
+use sqlparser::dialect::{GenericDialect, MsSqlDialect, MySqlDialect, PostgreSqlDialect};
+use sqlparser::parser::Parser;
+
+// ── Public types ──────────────────────────────────────────────────────────
+
+/// Outcome of a SQL build operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SqlBuildResult {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl SqlBuildResult {
+    fn ok(sql: String) -> Self {
+        Self { ok: true, sql: Some(sql), reason: None }
+    }
+
+    fn err(reason: impl Into<String>) -> Self {
+        Self { ok: false, sql: None, reason: Some(reason.into()) }
+    }
+}
+
+/// A single sort rule (column + direction).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SortRule {
+    pub column: String,
+    pub direction: SortDirection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SortDirection {
+    ASC,
+    DESC,
+}
+
+/// A single filter rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilterRule {
+    pub column: String,
+    pub operator: FilterOperator,
+    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value2: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FilterOperator {
+    Eq,
+    Neq,
+    Like,
+    Gt,
+    Lt,
+    Gte,
+    Lte,
+    Between,
+}
+
+/// Options for wrapping a user's SQL with sort/filter/pagination.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WrapQueryOptions {
+    /// The raw SQL from the editor.
+    pub original_sql: String,
+    /// Database type string ("postgres", "mysql", "sqlserver", "sqlite", etc.)
+    /// Automatically derived from the active connection when sent from the frontend.
+    #[serde(default)]
+    pub database_type: String,
+    /// Optional schema context for qualifying unqualified table references.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_context: Option<String>,
+    /// Sort rules.
+    #[serde(default)]
+    pub sort: Vec<SortRule>,
+    /// Filter rules.
+    #[serde(default)]
+    pub filters: Vec<FilterRule>,
+    /// Optional limit (None = no limit change).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    /// Optional offset (None = no offset change).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/// Build a wrapped SQL query with sort, filter, and pagination applied.
+///
+/// This is the main entry point. It:
+/// 1. Strips trailing semicolons and comments from the original SQL
+/// 2. Parses it with sqlparser to validate it's a single SELECT/WITH statement
+/// 3. Injects schema qualification if a schema_context is provided
+/// 4. Wraps it in a derived table if sort/filter/pagination are needed
+/// 5. Applies WHERE, ORDER BY, and LIMIT/OFFSET clauses
+pub fn wrap_query(options: WrapQueryOptions) -> SqlBuildResult {
+    // ── Step 1: Clean the SQL ──
+    let cleaned = strip_trailing(&options.original_sql);
+    if cleaned.is_empty() {
+        return SqlBuildResult::err("empty query");
+    }
+
+    // ── Step 2: Parse & extract a single statement ──
+    let dialect: Box<dyn sqlparser::dialect::Dialect> = match options.database_type.as_str() {
+        "postgres" | "duckdb" | "cockroachdb" => Box::new(PostgreSqlDialect {}),
+        "mysql" | "clickhouse" => Box::new(MySqlDialect {}),
+        "sqlserver" => Box::new(MsSqlDialect {}),
+        _ => Box::new(GenericDialect {}),
+    };
+
+    let stmts = match Parser::parse_sql(&*dialect, &cleaned) {
+        Ok(s) => s,
+        Err(e) => return SqlBuildResult::err(format!("parse error: {}", e)),
+    };
+
+    if stmts.is_empty() {
+        return SqlBuildResult::err("empty query after parsing");
+    }
+    if stmts.len() > 1 {
+        return SqlBuildResult::err("multiple statements are not supported for sort/filter");
+    }
+
+    let mut stmt = stmts.into_iter().next().unwrap();
+
+    // ── Step 3: Validate ──
+    if !is_select_statement(&stmt) {
+        return SqlBuildResult::err(
+            "only SELECT queries can be sorted or filtered",
+        );
+    }
+
+    // ── Step 4: Inject schema qualification ──
+    if let Some(ref schema) = options.schema_context {
+        if !schema.is_empty() {
+            inject_schema(&mut stmt, schema, &options.database_type);
+        }
+    }
+
+    // ── Step 5: Determine if we need wrapping ──
+    let needs_wrapping = !options.sort.is_empty()
+        || !options.filters.is_empty()
+        || options.limit.is_some()
+        || options.offset.is_some();
+
+    if !needs_wrapping {
+        // No sort/filter/pagination — return the (potentially schema-qualified) SQL as-is
+        return SqlBuildResult::ok(stmt_to_string(&stmt, &options.database_type));
+    }
+
+    // ── Step 6: Wrap in derived table ──
+    let inner_sql = stmt_to_string(&stmt, &options.database_type);
+    let alias = "_sqlkit_grid";
+    let quoted_alias = quote_ident(alias, &options.database_type);
+    let base = format!("SELECT * FROM ({}) AS {}", inner_sql, quoted_alias);
+
+    // ── Step 7: Apply filters ──
+    let base = if !options.filters.is_empty() {
+        let where_clause = build_filter_where(&options.filters, &options.database_type);
+        format!("{} WHERE {}", base, where_clause)
+    } else {
+        base
+    };
+
+    // ── Step 8: Extract SELECT columns for alias resolution ──
+    let select_columns = extract_select_columns(&stmt);
+    let has_expression_columns =
+        select_columns.iter().any(|(name, _)| name.contains(' ') || name.contains('('));
+
+    // ── Step 9: Apply sorting ──
+    let base = if !options.sort.is_empty() {
+        let order_by = build_order_by(
+            &options.sort,
+            &options.database_type,
+            &select_columns,
+            has_expression_columns,
+        );
+        format!("{} ORDER BY {}", base, order_by)
+    } else {
+        base
+    };
+
+    // ── Step 10: Apply pagination ──
+    let base = build_pagination(&base, options.limit, options.offset, &options.database_type);
+
+    SqlBuildResult::ok(base)
+}
+
+/// Strip trailing semicolons and SQL comments.
+pub fn strip_trailing(sql: &str) -> String {
+    let s = sql.trim();
+    // Strip single-line comments (-- ...) that trail after the main statement
+    let s = strip_trailing_line_comments(s);
+    // Strip trailing semicolons
+    s.trim_end().trim_end_matches(';').trim_end().to_string()
+}
+
+/// Remove trailing `-- line comments` and `/* block comments */`
+fn strip_trailing_line_comments(sql: &str) -> &str {
+    let sql = sql.trim_end();
+    // Handle multi-line: find last `--` or `/*` that starts a trailing comment
+    // We only strip comments that appear after the last meaningful token.
+    // Simple approach: find `--` and `/*` at the end
+    if let Some(pos) = sql.rfind("--") {
+        // Make sure the `--` is not inside a string literal (rough check)
+        let before = &sql[..pos];
+        if !before.contains('\'') || count_unmatched_quotes(before) % 2 == 0 {
+            return before.trim_end();
+        }
+    }
+    if let Some(pos) = sql.rfind("/*") {
+        let before = &sql[..pos];
+        if !before.contains('\'') || count_unmatched_quotes(before) % 2 == 0 {
+            if let Some(end) = sql[pos..].find("*/") {
+                let end_pos = pos + end + 2;
+                if end_pos >= sql.len() {
+                    return before.trim_end();
+                }
+            }
+        }
+    }
+    sql
+}
+
+fn count_unmatched_quotes(s: &str) -> usize {
+    let mut count = 0;
+    let mut in_string = false;
+    let mut prev_escape = false;
+    for ch in s.chars() {
+        if prev_escape {
+            prev_escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            prev_escape = true;
+            continue;
+        }
+        if ch == '\'' {
+            in_string = !in_string;
+            if !in_string {
+                count += 2; // matched pair
+            }
+        }
+    }
+    if in_string {
+        count + 1
+    } else {
+        count
+    }
+    // Return odd if there's an unmatched quote
+}
+
+// ── SQL building helpers ──
+
+fn build_filter_where(filters: &[FilterRule], db_type: &str) -> String {
+    let clauses: Vec<String> = filters
+        .iter()
+        .map(|f| {
+            let col = quote_ident(&f.column, db_type);
+            let esc = |v: &str| v.replace('\'', "''");
+            match f.operator {
+                FilterOperator::Eq => format!("{} = '{}'", col, esc(&f.value)),
+                FilterOperator::Neq => format!("{} != '{}'", col, esc(&f.value)),
+                FilterOperator::Like => {
+                    format!("{} LIKE '%{}%'", col, esc(&f.value))
+                }
+                FilterOperator::Gt => format!("{} > '{}'", col, esc(&f.value)),
+                FilterOperator::Lt => format!("{} < '{}'", col, esc(&f.value)),
+                FilterOperator::Gte => format!("{} >= '{}'", col, esc(&f.value)),
+                FilterOperator::Lte => format!("{} <= '{}'", col, esc(&f.value)),
+                FilterOperator::Between => {
+                    let v2 = f.value2.as_deref().unwrap_or("");
+                    format!(
+                        "{} >= '{}' AND {} <= '{}'",
+                        col,
+                        esc(&f.value),
+                        col,
+                        esc(v2)
+                    )
+                }
+            }
+        })
+        .collect();
+
+    clauses.join(" AND ")
+}
+
+fn build_order_by(
+    sort: &[SortRule],
+    db_type: &str,
+    select_columns: &[(String, usize)],
+    has_expression_columns: bool,
+) -> String {
+    sort.iter()
+        .map(|s| {
+            let dir = match s.direction {
+                SortDirection::ASC => "ASC",
+                SortDirection::DESC => "DESC",
+            };
+            // If the column is an expression in the SELECT list (not a bare column),
+            // use its positional alias
+            let col_ref = if has_expression_columns {
+                if let Some((_, idx)) = select_columns.iter().find(|(name, _)| name == &s.column) {
+                    // Column index is 1-based in SQL
+                    format!("{}", idx + 1)
+                } else {
+                    quote_ident(&s.column, db_type)
+                }
+            } else {
+                quote_ident(&s.column, db_type)
+            };
+            format!("{} {}", col_ref, dir)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn build_pagination(sql: &str, limit: Option<u64>, offset: Option<u64>, db_type: &str) -> String {
+    let limit = limit.unwrap_or(0);
+    let offset = offset.unwrap_or(0);
+
+    if limit == 0 && offset == 0 {
+        return sql.to_string();
+    }
+
+    match db_type {
+        "sqlserver" => {
+            if limit > 0 {
+                format!(
+                    "{} OFFSET {} ROWS FETCH NEXT {} ROWS ONLY",
+                    sql, offset, limit
+                )
+            } else {
+                format!("{} OFFSET {} ROWS", sql, offset)
+            }
+        }
+        _ => {
+            // PostgreSQL, MySQL, SQLite, etc.
+            if limit > 0 {
+                format!("{} LIMIT {} OFFSET {}", sql, limit, offset)
+            } else {
+                format!("{} LIMIT -1 OFFSET {}", sql, offset)
+            }
+        }
+    }
+}
+
+/// Quote a SQL identifier per database dialect.
+pub fn quote_ident(ident: &str, db_type: &str) -> String {
+    match db_type {
+        "postgres" | "sqlite" | "duckdb" | "jdbc" | "cockroachdb" => {
+            format!("\"{}\"", ident.replace('\"', "\"\""))
+        }
+        "mysql" | "clickhouse" => format!("`{}`", ident.replace('`', "``")),
+        "sqlserver" => format!("[{}]", ident.replace(']', "]]")),
+        _ => ident.to_string(),
+    }
+}
+
+// ── Schema injection ──
+
+/// Inject schema qualification into all unqualified table references.
+fn inject_schema(stmt: &mut Statement, schema: &str, db_type: &str) {
+    match stmt {
+        Statement::Query(query) => {
+            inject_schema_in_query(query, schema, db_type);
+        }
+        _ => {}
+    }
+}
+
+fn inject_schema_in_query(query: &mut Query, schema: &str, db_type: &str) {
+    inject_schema_in_query_body(query.body.as_mut(), schema, db_type);
+    // Also handle CTEs recursively
+    if let Some(ref mut with) = query.with {
+        for cte in with.cte_tables.iter_mut() {
+            inject_schema_in_query(cte.query.as_mut(), schema, db_type);
+        }
+    }
+}
+
+fn inject_schema_in_query_body(body: &mut SetExpr, schema: &str, db_type: &str) {
+    match body {
+        SetExpr::Select(select) => {
+            inject_schema_in_tables(&mut select.from, schema, db_type);
+        }
+        SetExpr::SetOperation { left, right, .. } => {
+            inject_schema_in_query_body(left.as_mut(), schema, db_type);
+            inject_schema_in_query_body(right.as_mut(), schema, db_type);
+        }
+        _ => {}
+    }
+}
+
+fn inject_schema_in_tables(tables: &mut Vec<TableWithJoins>, schema: &str, db_type: &str) {
+    for table in tables.iter_mut() {
+        inject_schema_in_table_factor(&mut table.relation, schema, db_type);
+        for join in table.joins.iter_mut() {
+            inject_schema_in_table_factor(&mut join.relation, schema, db_type);
+        }
+    }
+}
+
+fn inject_schema_in_table_factor(factor: &mut TableFactor, schema: &str, db_type: &str) {
+    match factor {
+        TableFactor::Table { ref mut name, .. } => {
+            // Only qualify if no schema is already present
+            if name.0.len() == 1 {
+                name.0
+                    .insert(0, ObjectNamePart::Identifier(Ident::new(schema)));
+            }
+        }
+        TableFactor::Derived { .. } | TableFactor::TableFunction { .. } => {
+            // Skip subqueries and table functions — they have their own scope
+        }
+        TableFactor::NestedJoin { table_with_joins, .. } => {
+            inject_schema_in_table_factor(&mut table_with_joins.relation, schema, db_type);
+            for join in table_with_joins.joins.iter_mut() {
+                inject_schema_in_table_factor(&mut join.relation, schema, db_type);
+            }
+        }
+        _ => {}
+    }
+}
+
+// ── AST helpers ──
+
+fn is_select_statement(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Query(query) => {
+            // SELECT, WITH, set operations (UNION, INTERSECT, EXCEPT) containing SELECT
+            match query.body.as_ref() {
+                SetExpr::Select(_) | SetExpr::SetOperation { .. } => true,
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Extract (column_name_or_alias, position) from SELECT list.
+fn extract_select_columns(stmt: &Statement) -> Vec<(String, usize)> {
+    match stmt {
+        Statement::Query(query) => match query.body.as_ref() {
+            SetExpr::Select(select) => extract_select_items(&select.projection),
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+fn extract_select_items(items: &[SelectItem]) -> Vec<(String, usize)> {
+    items
+        .iter()
+        .enumerate()
+        .map(|(i, item)| {
+            let name = match item {
+                SelectItem::UnnamedExpr(expr) => expr_to_name(expr),
+                SelectItem::ExprWithAlias { alias, .. } => alias.value.clone(),
+                SelectItem::QualifiedWildcard(kind, _) => match kind {
+                    SelectItemQualifiedWildcardKind::ObjectName(obj) => obj.to_string() + ".*",
+                    SelectItemQualifiedWildcardKind::Expr(e) => format!("({}).*", expr_to_name(e)),
+                },
+                SelectItem::Wildcard(_) => "*".to_string(),
+            };
+            (name, i)
+        })
+        .collect()
+}
+
+fn expr_to_name(expr: &Expr) -> String {
+    match expr {
+        Expr::Identifier(ident) => ident.value.clone(),
+        Expr::CompoundIdentifier(idents) => {
+            idents.iter().map(|i| i.value.clone()).collect::<Vec<_>>().join(".")
+        }
+        Expr::Function(f) => f.name.to_string(),
+        Expr::BinaryOp { left, op, right } => {
+            format!("{} {} {}", expr_to_name(left), op, expr_to_name(right))
+        }
+        Expr::Cast { expr, data_type, .. } => {
+            format!("CAST({} AS {})", expr_to_name(expr), data_type)
+        }
+        Expr::Value(vws) => match &vws.value {
+            Value::Number(n, _) => n.to_string(),
+            Value::SingleQuotedString(s) => format!("'{}'", s),
+            other => format!("{:?}", other),
+        },
+        _ => format!("{:?}", expr),
+    }
+}
+
+/// Convert a Statement back to SQL string.
+fn stmt_to_string(stmt: &Statement, _db_type: &str) -> String {
+    // Use the Display implementation which is dialect-aware via the parser dialect
+    stmt.to_string()
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_trailing_semicolon() {
+        assert_eq!(strip_trailing("SELECT 1;"), "SELECT 1");
+        assert_eq!(strip_trailing("SELECT 1;;;"), "SELECT 1");
+        assert_eq!(strip_trailing("  SELECT 1;  "), "SELECT 1");
+        assert_eq!(strip_trailing("SELECT 1"), "SELECT 1");
+        assert_eq!(strip_trailing(""), "");
+    }
+
+    #[test]
+    fn test_strip_trailing_comment() {
+        assert_eq!(strip_trailing("SELECT 1 -- comment"), "SELECT 1");
+        assert_eq!(strip_trailing("SELECT 1;-- comment"), "SELECT 1");
+        assert_eq!(
+            strip_trailing("SELECT 1 /* block comment */"),
+            "SELECT 1"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_comment_and_semicolons() {
+        assert_eq!(
+            strip_trailing("SELECT * FROM users ;-- WHERE id = '123'"),
+            "SELECT * FROM users"
+        );
+        assert_eq!(
+            strip_trailing("SELECT id, name FROM users; -- filter"),
+            "SELECT id, name FROM users"
+        );
+    }
+
+    #[test]
+    fn test_wrap_query_no_sort_filter() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT * FROM users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: None,
+            sort: vec![],
+            filters: vec![],
+            limit: None,
+            offset: None,
+        });
+        assert!(result.ok);
+        assert_eq!(result.sql.unwrap(), "SELECT * FROM users");
+    }
+
+    #[test]
+    fn test_wrap_query_trailing_semicolon_comment() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT * FROM users ;-- WHERE id = 'abc'".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: None,
+            sort: vec![],
+            filters: vec![],
+            limit: None,
+            offset: None,
+        });
+        assert!(result.ok, "should handle trailing semicolons: {:?}", result.reason);
+    }
+
+    #[test]
+    fn test_wrap_query_with_filter() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT * FROM users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: None,
+            sort: vec![],
+            filters: vec![FilterRule {
+                column: "id".to_string(),
+                operator: FilterOperator::Eq,
+                value: "42".to_string(),
+                value2: None,
+            }],
+            limit: None,
+            offset: None,
+        });
+        assert!(result.ok, "filter should succeed: {:?}", result.reason);
+        let sql = result.sql.unwrap();
+        assert!(sql.contains("WHERE"));
+        assert!(sql.contains("\"id\" = '42'"));
+    }
+
+    #[test]
+    fn test_wrap_query_with_sort() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT id, name FROM users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: None,
+            sort: vec![SortRule {
+                column: "name".to_string(),
+                direction: SortDirection::ASC,
+            }],
+            filters: vec![],
+            limit: None,
+            offset: None,
+        });
+        assert!(result.ok, "sort should succeed: {:?}", result.reason);
+        let sql = result.sql.unwrap();
+        assert!(sql.contains("ORDER BY"));
+        assert!(sql.contains("\"name\" ASC"));
+    }
+
+    #[test]
+    fn test_wrap_query_rejects_multi_statement() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT 1; DROP TABLE users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: None,
+            sort: vec![],
+            filters: vec![],
+            limit: None,
+            offset: None,
+        });
+        assert!(!result.ok, "multi-statement should be rejected");
+        assert!(result.reason.unwrap().contains("multiple"));
+    }
+
+    #[test]
+    fn test_wrap_query_rejects_dml() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "DELETE FROM users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: None,
+            sort: vec![],
+            filters: vec![],
+            limit: None,
+            offset: None,
+        });
+        assert!(!result.ok, "DML should be rejected");
+        assert!(result.reason.unwrap().contains("only SELECT"));
+    }
+
+    #[test]
+    fn test_wrap_query_with_pagination() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT * FROM users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: None,
+            sort: vec![],
+            filters: vec![],
+            limit: Some(50),
+            offset: Some(10),
+        });
+        assert!(result.ok, "pagination should succeed: {:?}", result.reason);
+        let sql = result.sql.unwrap();
+        assert!(sql.contains("LIMIT 50"));
+        assert!(sql.contains("OFFSET 10"));
+    }
+
+    #[test]
+    fn test_schema_injection() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT * FROM users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: Some("public".to_string()),
+            sort: vec![],
+            filters: vec![],
+            limit: None,
+            offset: None,
+        });
+        assert!(result.ok, "schema injection should succeed: {:?}", result.reason);
+        let sql = result.sql.unwrap();
+        // The table should now be qualified as "public"."users"
+        assert!(sql.contains("public") && sql.contains("users"));
+    }
+
+    #[test]
+    fn test_wrap_query_all_together() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT id, name, email FROM users".to_string(),
+            database_type: "postgres".to_string(),
+            schema_context: Some("public".to_string()),
+            sort: vec![
+                SortRule { column: "name".to_string(), direction: SortDirection::ASC },
+            ],
+            filters: vec![
+                FilterRule {
+                    column: "email".to_string(),
+                    operator: FilterOperator::Like,
+                    value: "test".to_string(),
+                    value2: None,
+                },
+            ],
+            limit: Some(100),
+            offset: Some(0),
+        });
+        assert!(result.ok, "all combined: {:?}", result.reason);
+        let sql = result.sql.unwrap();
+        // Schema is injected as unqualified table ref → "public.users" or "public"."users"
+        assert!(
+            sql.contains("public.") || sql.contains("\"public\""),
+            "schema not found in: {}",
+            sql
+        );
+        assert!(sql.contains("WHERE"), "where: {}", sql);
+        assert!(sql.contains("ORDER BY"), "order: {}", sql);
+        assert!(sql.contains("LIMIT 100"), "limit: {}", sql);
+    }
+
+    #[test]
+    fn test_mysql_dialect() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT * FROM users ORDER BY name".to_string(),
+            database_type: "mysql".to_string(),
+            schema_context: None,
+            sort: vec![SortRule {
+                column: "name".to_string(),
+                direction: SortDirection::DESC,
+            }],
+            filters: vec![],
+            limit: Some(10),
+            offset: None,
+        });
+        assert!(result.ok, "mysql: {:?}", result.reason);
+        let sql = result.sql.unwrap();
+        // MySQL uses backtick quoting
+        assert!(sql.contains('`'), "mysql should use backticks: {}", sql);
+    }
+
+    #[test]
+    fn test_sqlserver_dialect() {
+        let result = wrap_query(WrapQueryOptions {
+            original_sql: "SELECT * FROM users".to_string(),
+            database_type: "sqlserver".to_string(),
+            schema_context: None,
+            sort: vec![SortRule {
+                column: "name".to_string(),
+                direction: SortDirection::ASC,
+            }],
+            filters: vec![],
+            limit: Some(10),
+            offset: Some(0),
+        });
+        assert!(result.ok, "sqlserver: {:?}", result.reason);
+        let sql = result.sql.unwrap();
+        assert!(sql.contains("OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,6 +243,7 @@ pub fn run() {
             commands::get_connection_quality,
             // Query execution commands
             commands::execute_query,
+            commands::execute_sorted_query,
             commands::cancel_query,
             commands::explain_query,
             // Database browsing commands

--- a/src/components/database-browser/QueryResultPanel.vue
+++ b/src/components/database-browser/QueryResultPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { QueryResult } from '@/store/tabStore'
-import type { ApiError } from '@/types/api'
+import type { ApiError, ApiResponse } from '@/types/api'
 import type { ExplainResult } from '@/types/explainPlan'
 import type { ColumnFilter, SortColumn } from '@/types/grid'
 import { invoke } from '@tauri-apps/api/core'
@@ -12,7 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDataGridCopy } from '@/composables/useDataGridCopy'
-import { formatApiError } from '@/types/api'
+import { formatApiError, isApiError } from '@/types/api'
 
 type Props = {
   results?: QueryResult | null
@@ -80,7 +80,7 @@ const formattedTime = computed(() => {
     : `${(props.executionTime / 1000).toFixed(2)}s`
 })
 
-// ── Sort/Filter Re-execution ──
+// ── Sort/Filter Re-execution (backend-driven) ──
 const gridLoading = ref(false)
 const gridError = ref<string | null>(null)
 const gridResults = ref<QueryResult | null>(null)
@@ -95,50 +95,6 @@ watch(() => props.results, (r) => {
     gridError.value = null
   }
 }, { immediate: true })
-
-function buildWrappedSql(sort: SortColumn[], filters: ColumnFilter[]): string {
-  if (!props.sql)
-    return props.sql ?? ''
-  let sql = `SELECT * FROM (${props.sql}) AS _sqlkit_grid`
-
-  // Build WHERE clause
-  if (filters.length > 0) {
-    const clauses = filters.map((f) => {
-      const esc = (v: string) => v.replace(/'/g, '\'\'')
-      const col = f.column
-      switch (f.operator) {
-        case 'eq':
-          return `${col} = '${esc(f.value)}'`
-        case 'neq':
-          return `${col} != '${esc(f.value)}'`
-        case 'like':
-          return `${col} LIKE '%${esc(f.value)}%'`
-        case 'gt':
-          return `${col} > '${esc(f.value)}'`
-        case 'lt':
-          return `${col} < '${esc(f.value)}'`
-        case 'gte':
-          return `${col} >= '${esc(f.value)}'`
-        case 'lte':
-          return `${col} <= '${esc(f.value)}'`
-        case 'between':
-          return `${col} >= '${esc(f.value)}' AND ${col} <= '${esc(f.value2 ?? '')}'`
-        default:
-          return ''
-      }
-    }).filter(Boolean)
-    if (clauses.length > 0) {
-      sql += ` WHERE ${clauses.join(' AND ')}`
-    }
-  }
-
-  // Build ORDER BY clause
-  if (sort.length > 0) {
-    sql += ` ORDER BY ${sort.map(s => `${s.column} ${s.direction}`).join(', ')}`
-  }
-
-  return sql
-}
 
 async function handleSortChange(sort: SortColumn[]) {
   activeSort.value = sort
@@ -158,18 +114,35 @@ async function reExecuteWithSortFilter() {
   gridError.value = null
 
   try {
-    const wrappedSql = buildWrappedSql(activeSort.value, activeFilters.value)
     const start = performance.now()
-    const result = await invoke<{ status: string, data: QueryResult }>('execute_query', {
+    const result = await invoke<ApiResponse<QueryResult>>('execute_sorted_query', {
       connectionId: props.connectionId,
-      sql: wrappedSql,
       database: props.database ?? null,
+      options: {
+        originalSql: props.sql,
+        schemaContext: props.schema ?? null,
+        sort: activeSort.value.map(s => ({
+          column: s.column,
+          direction: s.direction === 'ASC' ? 'ASC' : 'DESC',
+        })),
+        filters: activeFilters.value.map(f => ({
+          column: f.column,
+          operator: f.operator.toUpperCase(),
+          value: f.value,
+          value2: f.value2 ?? null,
+        })),
+        limit: null,
+        offset: null,
+      },
     })
     const elapsed = Math.round(performance.now() - start)
 
     if (result.status === 'success') {
       gridResults.value = result.data
       gridExecutionTimeMs.value = elapsed
+    }
+    else if (isApiError(result)) {
+      gridError.value = formatApiError(result.error, t)
     }
     else {
       gridError.value = t('components.queryResult.error')
@@ -395,6 +368,7 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
           :schema="schema"
           :loading="displayExecuting"
           :hide-toolbar="true"
+          :hide-batch-actions="true"
           :error="displayErrorMessage"
           @sort-change="handleSortChange"
           @filter-change="handleFilterChange"

--- a/src/components/grid/DataGrid.vue
+++ b/src/components/grid/DataGrid.vue
@@ -49,6 +49,7 @@ type Props = {
   schema?: string
   connectionId?: string
   hideToolbar?: boolean
+  hideBatchActions?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -62,6 +63,7 @@ const props = withDefaults(defineProps<Props>(), {
   schema: undefined,
   connectionId: undefined,
   hideToolbar: false,
+  hideBatchActions: false,
 })
 
 const emit = defineEmits<DataGridEmits>()
@@ -523,7 +525,72 @@ watch(() => [props.rows, props.columns], () => {
 
     <!-- Grid Content -->
     <div v-else class="flex flex-1 flex-col min-h-0">
-      <!-- Scroll container -->
+      <!-- Header (outside scroll container — never overlaps rows) -->
+      <div
+        class="border-b bg-muted flex flex-shrink-0"
+      >
+        <!-- Select-All Checkbox -->
+        <div class="flex flex-shrink-0 h-8 w-10 items-center justify-center">
+          <Checkbox
+            :checked="selection.isAllSelected(rows.length)"
+            @update:checked="selection.toggleAll(rows.length)"
+          />
+        </div>
+        <!-- Column Headers -->
+        <div
+          v-for="col in columns"
+          :key="col"
+          class="group flex flex-shrink-0 items-center relative"
+          :style="{ width: `${getColumnWidth(col)}px` }"
+          @contextmenu.prevent="openHeaderContextMenu($event, col)"
+        >
+          <button
+            class="px-3 py-1.5 text-left flex flex-1 gap-1 min-w-0 items-center"
+            :class="sort.getSortDirection(col) ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'"
+            @click="sort.toggleSort(col, ($event as MouseEvent).shiftKey); emit('sortChange', sort.sortState.value)"
+          >
+            <span class="text-xs font-medium truncate">{{ col }}</span>
+            <span
+              v-if="sort.getSortDirection(col) === 'ASC'"
+              class="i-carbon-arrow-up flex-shrink-0 h-3 w-3"
+            />
+            <span
+              v-else-if="sort.getSortDirection(col) === 'DESC'"
+              class="i-carbon-arrow-down flex-shrink-0 h-3 w-3"
+            />
+            <span
+              v-else
+              class="i-carbon-chevron-sort opacity-0 flex-shrink-0 h-3 w-3 transition-opacity group-hover:opacity-40"
+            />
+            <!-- Multi-sort priority -->
+            <span
+              v-if="sort.getSortPriority(col)"
+              class="text-[10px] text-primary leading-tight font-bold px-1 rounded bg-primary/10 flex-shrink-0"
+            >{{ sort.getSortPriority(col) }}</span>
+            <!-- Filter indicator -->
+            <span
+              v-if="filter.hasFilter(col)"
+              class="i-carbon-filter text-blue-500 flex-shrink-0 h-3 w-3"
+            />
+          </button>
+          <!-- Resize Handle -->
+          <div
+            class="opacity-0 w-1 cursor-col-resize transition-opacity bottom-0 right-0 top-0 absolute z-10 hover:bg-primary/40 group-hover:opacity-100"
+            @mousedown.stop="startColumnResize($event, col)"
+          />
+        </div>
+        <!-- Actions Column Header -->
+        <div
+          v-if="connectionId"
+          class="bg-muted flex-shrink-0 w-10 right-0 sticky z-10"
+        >
+          <div class="flex h-8 items-center justify-center">
+            <span class="i-carbon-overflow-menu-vertical text-muted-foreground h-3.5 w-3.5" />
+          </div>
+        </div>
+      </div>
+
+      <!-- Scroll container (rows only) -->
       <div
         ref="scrollContainer"
         class="flex-1 relative overflow-auto"
@@ -533,71 +600,6 @@ watch(() => [props.rows, props.columns], () => {
           :style="{ height: `${rowVirtualizer.getTotalSize()}px` }"
           class="relative"
         >
-          <!-- Sticky Header -->
-          <div
-            class="border-b bg-muted flex top-0 sticky z-20"
-          >
-            <!-- Select-All Checkbox -->
-            <div class="flex flex-shrink-0 h-8 w-10 items-center justify-center">
-              <Checkbox
-                :checked="selection.isAllSelected(rows.length)"
-                @update:checked="selection.toggleAll(rows.length)"
-              />
-            </div>
-            <!-- Column Headers -->
-            <div
-              v-for="col in columns"
-              :key="col"
-              class="group flex flex-shrink-0 items-center relative"
-              :style="{ width: `${getColumnWidth(col)}px` }"
-              @contextmenu.prevent="openHeaderContextMenu($event, col)"
-            >
-              <button
-                class="px-3 py-1.5 text-left flex flex-1 gap-1 min-w-0 items-center"
-                :class="sort.getSortDirection(col) ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'"
-                @click="sort.toggleSort(col, ($event as MouseEvent).shiftKey); emit('sortChange', sort.sortState.value)"
-              >
-                <span class="text-xs font-medium truncate">{{ col }}</span>
-                <span
-                  v-if="sort.getSortDirection(col) === 'ASC'"
-                  class="i-carbon-arrow-up flex-shrink-0 h-3 w-3"
-                />
-                <span
-                  v-else-if="sort.getSortDirection(col) === 'DESC'"
-                  class="i-carbon-arrow-down flex-shrink-0 h-3 w-3"
-                />
-                <span
-                  v-else
-                  class="i-carbon-chevron-sort opacity-0 flex-shrink-0 h-3 w-3 transition-opacity group-hover:opacity-40"
-                />
-                <!-- Multi-sort priority -->
-                <span
-                  v-if="sort.getSortPriority(col)"
-                  class="text-[10px] text-primary leading-tight font-bold px-1 rounded bg-primary/10 flex-shrink-0"
-                >{{ sort.getSortPriority(col) }}</span>
-                <!-- Filter indicator -->
-                <span
-                  v-if="filter.hasFilter(col)"
-                  class="i-carbon-filter text-blue-500 flex-shrink-0 h-3 w-3"
-                />
-              </button>
-              <!-- Resize Handle -->
-              <div
-                class="opacity-0 w-1 cursor-col-resize transition-opacity bottom-0 right-0 top-0 absolute z-10 hover:bg-primary/40 group-hover:opacity-100"
-                @mousedown.stop="startColumnResize($event, col)"
-              />
-            </div>
-            <!-- Actions Column Header -->
-            <div
-              v-if="connectionId"
-              class="bg-muted flex-shrink-0 w-10 right-0 sticky z-10"
-            >
-              <div class="flex h-8 items-center justify-center">
-                <span class="i-carbon-overflow-menu-vertical text-muted-foreground h-3.5 w-3.5" />
-              </div>
-            </div>
-          </div>
-
           <!-- Virtual Rows -->
           <div
             v-for="virtualRow in rowVirtualizer.getVirtualItems()"
@@ -745,6 +747,7 @@ watch(() => [props.rows, props.columns], () => {
 
       <!-- Batch Action Bar -->
       <BatchActionBar
+        v-if="!hideBatchActions"
         :selected-count="selection.selectedCount.value"
         :selected-rows="selection.getSelectedRows(rows)"
         :columns="columns"

--- a/src/composables/useSqlStatements.ts
+++ b/src/composables/useSqlStatements.ts
@@ -18,114 +18,217 @@ export type StatementToExecute = {
   found: boolean
 }
 
-// Matches DML/DDL keywords that begin a SQL statement at line start (case-insensitive)
-// Also matches parentheses wrapping keywords (for subqueries like (SELECT...))
-const SQL_STATEMENT_START_REGEX
-  = /^\s*(?:\(\s*)?(?:SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|WITH|EXPLAIN|CALL|EXEC|MERGE|REPLACE|SHOW|DESCRIBE|DESC|USE|SET|BEGIN|COMMIT|ROLLBACK|SAVEPOINT|PRAGMA|VACUUM|GRANT|REVOKE|ATTACH|DETACH|ANALYZE|REINDEX|LOAD|UNLOAD|COPY|LOCK|UNLOCK)\b/i
+// ── Character-based SQL statement splitter ──
+// Replaces the old line-based + regex approach that broke on correlated
+// subqueries spanning multiple lines (e.g. (SELECT count(*) ...) as alias).
+// This is the same algorithm dbx uses in Rust: character-by-character,
+// tracking quote/comment context, and splitting only on `;` outside of quotes.
 
-const isStatementStart = (line: string): boolean => SQL_STATEMENT_START_REGEX.test(line)
-
-type LineTokens = {
-  semicolonIndex: number
-  parenDelta: number
+type ScannerState = {
+  inSingleQuote: boolean
+  inDoubleQuote: boolean
+  inBacktick: boolean
+  inLineComment: boolean
+  inBlockComment: boolean
+  prevChar: string | null
+  dollarTag: string | null
 }
 
-function tokenizeLine(line: string): LineTokens {
-  let singleQuote = false
-  let doubleQuote = false
-  let parenDelta = 0
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i]
-    if (ch === '\'' && !doubleQuote) {
-      if (singleQuote && line[i + 1] === '\'') {
-        i++
+type StatementRange = {
+  text: string
+  startOffset: number
+  endOffset: number
+  startLine: number
+  endLine: number
+}
+
+const DEFAULT_STATE: ScannerState = {
+  inSingleQuote: false,
+  inDoubleQuote: false,
+  inBacktick: false,
+  inLineComment: false,
+  inBlockComment: false,
+  prevChar: null,
+  dollarTag: null,
+}
+
+function isOutsideString(state: ScannerState): boolean {
+  return !state.inSingleQuote && !state.inDoubleQuote && !state.inBacktick
+}
+
+function scanStatements(content: string): StatementRange[] {
+  const ranges: StatementRange[] = []
+  const state: ScannerState = { ...DEFAULT_STATE }
+  let bufStart = 0
+  let line = 1
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]
+    const next = i + 1 < content.length ? content[i + 1] : null
+
+    // Track lines
+    if (ch === '\n') {
+      line++
+    }
+
+    // Handle dollar-quoting (PostgreSQL $$...$$)
+    if (state.dollarTag) {
+      const tag = state.dollarTag
+      if (content.startsWith(tag, i)) {
+        state.dollarTag = null
+        i += tag.length - 1
+        state.prevChar = tag[tag.length - 1]
         continue
       }
-      singleQuote = !singleQuote
+      state.prevChar = ch
+      continue
     }
-    else if (ch === '"' && !singleQuote) {
-      doubleQuote = !doubleQuote
+
+    if (state.inLineComment) {
+      if (ch === '\n') {
+        state.inLineComment = false
+      }
+      state.prevChar = ch
+      continue
     }
-    else if (ch === '-' && line[i + 1] === '-' && !singleQuote && !doubleQuote) {
-      break
+
+    if (state.inBlockComment) {
+      if (ch === '/' && state.prevChar === '*') {
+        state.inBlockComment = false
+      }
+      state.prevChar = ch
+      continue
     }
-    else if (!singleQuote && !doubleQuote) {
-      if (ch === '(')
-        parenDelta++
-      else if (ch === ')')
-        parenDelta--
-      else if (ch === ';')
-        return { semicolonIndex: i, parenDelta }
+
+    // Start line comment?
+    if (isOutsideString(state) && ch === '-' && next === '-') {
+      state.inLineComment = true
+      state.prevChar = ch
+      continue
     }
-  }
-  return { semicolonIndex: -1, parenDelta }
-}
 
-const WITH_REGEX = /^\s*WITH\b/i
-const UPDATE_REGEX = /^\s*UPDATE\b/i
-const SET_REGEX = /^\s*SET\b/i
+    // Hash comment (MySQL dialect)?
+    if (isOutsideString(state) && ch === '#') {
+      state.inLineComment = true
+      state.prevChar = ch
+      continue
+    }
 
-function isUpdateContinuation(line: string, startKeyword: string): boolean {
-  return UPDATE_REGEX.test(startKeyword) && SET_REGEX.test(line)
-}
+    // Start block comment?
+    if (isOutsideString(state) && ch === '/' && next === '*') {
+      state.inBlockComment = true
+      state.prevChar = ch
+      continue
+    }
 
-function findStatementEnd(lines: string[], startLine: number): number {
-  const isCte = WITH_REGEX.test(lines[startLine])
-  const startKeyword = lines[startLine]
-  let parenDepth = 0
-
-  for (let i = startLine; i < lines.length; i++) {
-    const { semicolonIndex, parenDelta } = tokenizeLine(lines[i])
-    if (semicolonIndex !== -1)
-      return i
-
-    parenDepth += parenDelta
-
-    if (i > startLine && parenDepth === 0 && !isCte && isStatementStart(lines[i].trim())) {
-      if (isUpdateContinuation(lines[i], startKeyword))
+    // Dollar-quote start (PostgreSQL)?
+    if (isOutsideString(state) && ch === '$') {
+      const tagEnd = content.indexOf('$', i + 1)
+      if (tagEnd !== -1) {
+        const tag = content.slice(i, tagEnd + 1)
+        state.dollarTag = tag
+        state.prevChar = ch
         continue
-      return i - 1
+      }
+    }
+
+    // Quote tracking
+    if (ch === '\'' && !state.inDoubleQuote && !state.inBacktick) {
+      if (state.inSingleQuote && next === '\'') {
+        i++ // skip escaped quote
+        state.prevChar = ch
+        continue
+      }
+      state.inSingleQuote = !state.inSingleQuote
+      state.prevChar = ch
+      continue
+    }
+
+    if (ch === '"' && !state.inSingleQuote && !state.inBacktick) {
+      if (state.inDoubleQuote && next === '"') {
+        i++ // skip escaped quote
+        state.prevChar = ch
+        continue
+      }
+      state.inDoubleQuote = !state.inDoubleQuote
+      state.prevChar = ch
+      continue
+    }
+
+    if (ch === '`' && !state.inSingleQuote && !state.inDoubleQuote) {
+      state.inBacktick = !state.inBacktick
+      state.prevChar = ch
+      continue
+    }
+
+    // Statement separator: semicolon outside quotes
+    if (ch === ';' && isOutsideString(state) && !state.inLineComment && !state.inBlockComment) {
+      const text = content.slice(bufStart, i + 1)
+      const textTrimmed = text.trim()
+      if (textTrimmed.length > 0) {
+        ranges.push(buildRange(content, bufStart, i + 1))
+      }
+      bufStart = i + 1
+      state.prevChar = ch
+      continue
+    }
+
+    state.prevChar = ch
+  }
+
+  // Trailing statement (no trailing semicolon)
+  if (bufStart < content.length) {
+    const text = content.slice(bufStart)
+    if (text.trim().length > 0) {
+      ranges.push(buildRange(content, bufStart, content.length))
     }
   }
-  return lines.length - 1
+
+  return ranges
+}
+
+function buildRange(content: string, start: number, end: number): StatementRange {
+  return {
+    text: content.slice(start, end),
+    startOffset: start,
+    endOffset: end,
+    startLine: lineAtOffset(content, start),
+    endLine: lineAtOffset(content, end),
+  }
+}
+
+function lineAtOffset(content: string, offset: number): number {
+  let line = 1
+  for (let i = 0; i < offset && i < content.length; i++) {
+    if (content[i] === '\n') {
+      line++
+    }
+  }
+  return line
 }
 
 export function parseSqlStatements(content: string): SqlStatement[] {
+  const ranges = scanStatements(content)
   const lines = content.split('\n')
-  const statements: SqlStatement[] = []
-  let i = 0
 
-  while (i < lines.length) {
-    const trimmed = lines[i].trim()
-    if (trimmed === '' || trimmed.startsWith('--') || trimmed.startsWith('//')) {
-      i++
-      continue
-    }
-    if (!isStatementStart(trimmed)) {
-      i++
-      continue
-    }
-
-    const startLine = i
-    const endLine = findStatementEnd(lines, startLine)
-    const statement = lines.slice(startLine, endLine + 1).join('\n').trim().replace(/;\s*$/, '')
-
-    if (statement.length > 0) {
-      statements.push({
+  return ranges
+    .filter((r) => {
+      // Remove trailing semicolon for the statement text
+      const t = r.text.trim().replace(/;\s*$/, '').trim()
+      return t.length > 0
+    })
+    .map((r) => {
+      const statement = r.text.trim().replace(/;\s*$/, '').trim()
+      return {
         statement,
         position: {
-          startLineNumber: startLine + 1,
-          endLineNumber: endLine + 1,
+          startLineNumber: r.startLine,
+          endLineNumber: r.endLine,
           startColumn: 1,
-          endColumn: lines[endLine].length + 1,
+          endColumn: (lines[r.endLine - 1]?.length ?? 1) + 1,
         },
-      })
-    }
-
-    i = endLine + 1
-  }
-
-  return statements
+      }
+    })
 }
 
 export function getStatementAtLine(statements: SqlStatement[], lineNumber: number): SqlStatement | undefined {


### PR DESCRIPTION
## Summary

Moves all SQL construction (wrapping, filtering, sorting, pagination) from the frontend to the backend with proper `sqlparser`-based parsing and validation.

## Changes

### sql_service.rs (new)
Centralized SQL construction service. Handles:
- Stripping trailing semicolons and `--` comments before wrapping
- Parsing with `sqlparser` to validate single SELECT/WITH statements
- Injecting schema qualification on unqualified table references
- Building WHERE/ORDER BY/LIMIT clauses from structured data
- Rejecting multi-statement or DML input with clear error messages

### QueryResultPanel.vue
- Removed `buildWrappedSql` — frontend no longer constructs SQL strings
- Sends structured sort/filter state to new `execute_sorted_query` command
- Backend derives database type from active connection

### DataGrid.vue
- Fixed virtual scroller: column header moved outside scroll container
  so rows are never hidden behind the sticky header
- Added `hideBatchActions` prop to suppress batch action bar in query
  result panel

### useSqlStatements.ts
- Replaced line-based + regex statement parser with a character-based
  state machine that tracks quotes, backticks, and comments
- Fixes false splitting of correlated subqueries like
  `(SELECT count(*) FROM t WHERE x = y) as alias`

### search.rs
- UUID columns use `::text` cast instead of `CAST(... AS TEXT)`
- Added exact-match optimization for UUID-formatted search terms
- JSON/JSONB columns also use `::text` for compatibility

## Testing
- 14 new unit tests for sql_service.rs covering: trailing semicolons,
  comments, multi-statement rejection, DML rejection, schema injection,
  filter/sort/pagination, MySQL and SQL Server dialects
- All 286 existing Rust tests pass
- All 416 frontend tests pass