### PR TITLE
fix: sidebar navigation, result panel icons, DataGrid row selection and actions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6433,7 +6433,7 @@ dependencies = [
 
 [[package]]
 name = "sqlkit"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/components/database-browser/QueryResultPanel.vue
+++ b/src/components/database-browser/QueryResultPanel.vue
@@ -257,8 +257,8 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="sm" class="text-foreground p-0 h-8 w-8 hover:bg-muted" @click="copyUtil.copyRowsAs(displayResults.rows, displayResults.columns, 'csv')">
-                <span class="i-carbon-table-split h-4.5 w-4.5" />
+              <Button variant="ghost" size="icon" class="text-sky-600 h-7 w-7 dark:text-sky-400 hover:bg-sky-500/10 dark:hover:bg-sky-500/20" @click="copyUtil.copyRowsAs(displayResults.rows, displayResults.columns, 'csv')">
+                <span class="i-lucide-file-spreadsheet shrink-0 h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{{ t('components.dataGrid.export.copyAllCsv') }}</TooltipContent>
@@ -267,8 +267,8 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="sm" class="text-foreground p-0 h-8 w-8 hover:bg-muted" @click="copyUtil.copyRowsAs(displayResults.rows, displayResults.columns, 'json')">
-                <span class="i-carbon-code h-4.5 w-4.5" />
+              <Button variant="ghost" size="icon" class="text-amber-600 h-7 w-7 dark:text-amber-400 hover:bg-amber-500/10 dark:hover:bg-amber-500/20" @click="copyUtil.copyRowsAs(displayResults.rows, displayResults.columns, 'json')">
+                <span class="i-lucide-file-json shrink-0 h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{{ t('components.dataGrid.export.copyAllJson') }}</TooltipContent>
@@ -277,19 +277,19 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="sm" class="text-foreground p-0 h-8 w-8 hover:bg-muted" @click="copyUtil.copyRowsAs(displayResults.rows, displayResults.columns, 'insert')">
-                <span class="i-carbon-sql h-4.5 w-4.5" />
+              <Button variant="ghost" size="icon" class="text-emerald-600 h-7 w-7 dark:text-emerald-400 hover:bg-emerald-500/10 dark:hover:bg-emerald-500/20" @click="copyUtil.copyRowsAs(displayResults.rows, displayResults.columns, 'insert')">
+                <span class="i-lucide-database shrink-0 h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{{ t('components.dataGrid.export.copyAllInsert') }}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        <span class="text-xs text-muted-foreground mx-1">|</span>
+        <div class="mx-0.5 bg-border h-4 w-px" />
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="sm" class="text-foreground p-0 h-8 w-8 hover:bg-muted" @click="copyUtil.exportToFile(displayResults.rows, displayResults.columns, 'csv')">
-                <span class="i-carbon-document-export h-4.5 w-4.5" />
+              <Button variant="ghost" size="icon" class="text-sky-600 h-7 w-7 dark:text-sky-400 hover:bg-sky-500/10 dark:hover:bg-sky-500/20" @click="copyUtil.exportToFile(displayResults.rows, displayResults.columns, 'csv')">
+                <span class="i-lucide-file-down shrink-0 h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{{ t('components.dataGrid.export.exportCsv') }}</TooltipContent>
@@ -298,8 +298,8 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="sm" class="text-foreground p-0 h-8 w-8 hover:bg-muted" @click="copyUtil.exportToFile(displayResults.rows, displayResults.columns, 'json')">
-                <span class="i-carbon-document-export h-4.5 w-4.5" />
+              <Button variant="ghost" size="icon" class="text-amber-600 h-7 w-7 dark:text-amber-400 hover:bg-amber-500/10 dark:hover:bg-amber-500/20" @click="copyUtil.exportToFile(displayResults.rows, displayResults.columns, 'json')">
+                <span class="i-lucide-file-down shrink-0 h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{{ t('components.dataGrid.export.exportJson') }}</TooltipContent>
@@ -315,11 +315,11 @@ const displayExecutionTime = computed(() => gridExecutionTimeMs.value ?? props.e
       <Button
         variant="ghost"
         size="icon"
-        class="h-6 w-6"
+        class="text-muted-foreground h-7 w-7 hover:text-foreground"
         :title="t('components.queryResult.close')"
         @click="close"
       >
-        <span class="i-carbon-close h-3.5 w-3.5" />
+        <span class="i-lucide-x shrink-0 h-3.5 w-3.5" />
       </Button>
     </div>
 

--- a/src/components/grid/DataGrid.vue
+++ b/src/components/grid/DataGrid.vue
@@ -634,7 +634,6 @@ watch(() => [props.rows, props.columns], () => {
               :class="getCellClass(columnTypes?.[col])"
               :style="{ width: `${getColumnWidth(col)}px` }"
               :title="getCellTooltip(rows[virtualRow.index][col])"
-              @click="selection.toggleRow(virtualRow.index, false)"
               @contextmenu.prevent="openCellContextMenu($event, virtualRow.index, col)"
             >
               <!-- NULL -->
@@ -695,7 +694,7 @@ watch(() => [props.rows, props.columns], () => {
             <!-- Row Actions -->
             <div
               v-if="connectionId"
-              class="bg-background/80 opacity-0 flex flex-shrink-0 w-10 transition-opacity items-center right-0 justify-center sticky z-10 group-hover:opacity-100"
+              class="bg-background/80 flex flex-shrink-0 w-10 items-center right-0 justify-center sticky z-10"
               @click.stop
             >
               <DropdownMenu>

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -47,7 +47,7 @@ const { t } = useI18n()
                       ? 'bg-secondary text-primary border border-border shadow-sm'
                       : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
                 ]"
-                @click="item.id === 'github' ? openUrl('https://github.com/geek-fun/sqlkit') : navigate"
+                @click="item.id === 'github' ? openUrl('https://github.com/geek-fun/sqlkit') : navigate()"
               >
                 <!-- DNS icon -->
                 <svg


### PR DESCRIPTION
## Summary

Fixes three UI issues and one visual polish pass.

## Changes

| Commit | Description |
|--------|-------------|
| 4b267e4 | fix sidebar navigation - @click ternary returned navigate function reference without calling it |
| af432c6 | unify result panel icons with editor toolbar style (semantic colors, consistent sizing, lucide icons) |
| 266ecf0 | DataGrid row selection only from checkbox, not cell click; actions column always visible |

### Sidebar Navigation
Vue 3 compiles simple @click="navigate" correctly, but complex expressions like `condition ? fn() : navigate` evaluate to the function without calling it. Changed to navigate().

### Result Panel Icons
- Colors: CSV -> sky, JSON -> amber, SQL -> emerald (matches editor toolbar pattern)
- Buttons: h-7 w-7 (was h-8 w-8)
- Icons: h-3.5 w-3.5 (was h-4.5 w-4.5)
- Icon set: i-lucide (was i-carbon)
- Divider: proper border (was text pipe)

### DataGrid
- Removed @click toggleRow from data cells - selection only from checkbox
- Removed opacity-0 / group-hover from actions column - always visible