### PR TITLE
feat: soft-split SQL statements at 2+ blank lines when ; is missing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6433,7 +6433,7 @@ dependencies = [
 
 [[package]]
 name = "sqlkit"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -470,12 +470,24 @@ function toggleColumn(col: string) {
     : new Set([...hiddenColumns.value, col])
 }
 
+function formatTimestamp(): string {
+  const d = new Date()
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}`
+}
+
 async function exportCSV() {
   if (!data.value)
     return
 
   const csv = rowsToCsv(data.value.rows, visibleColumns.value)
-  const defaultName = `${props.tableName}.csv`
+  const conn = connectionStore.getConnectionById(props.connectionId)
+  const connName = conn?.name || props.connectionId
+  const parts = [connName, props.database]
+  if (props.schema)
+    parts.push(props.schema)
+  parts.push(props.tableName, formatTimestamp())
+  const defaultName = `${parts.join('-')}.csv`
 
   try {
     const selectedPath = await showSaveDialog({

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -910,41 +910,42 @@ watch(
           @click.stop="refresh"
         >
           <span class="i-carbon-renew h-3.5 w-3.5" :class="{ 'animate-spin': loading }" />
-          <!-- Column visibility dropdown -->
-          <div class="flex-shrink-0 relative">
-            <Button
-              variant="ghost"
-              size="icon"
-              class="h-7 w-7"
-              :title="t('components.dataTableView.columns')"
-              @click.stop="showColumnMenu = !showColumnMenu"
-            >
-              <span class="i-carbon-table-split h-3.5 w-3.5" />
-            </Button>
+        </Button>
 
-            <div
-              v-if="showColumnMenu && data && data.columns.length > 0"
-              class="text-popover-foreground mt-1 border rounded-md bg-popover max-h-64 min-w-36 shadow-md right-0 top-full absolute z-50 overflow-auto"
-              @click.stop
-            >
-              <div class="text-xs text-muted-foreground font-semibold p-1 px-2 py-1.5 border-b">
-                {{ t('components.dataTableView.columns') }}
-              </div>
-              <div class="p-1">
-                <button
-                  v-for="col in data.columns"
-                  :key="col"
-                  class="text-sm px-2 py-1 text-left rounded flex gap-2 w-full cursor-pointer items-center hover:bg-accent"
-                  @click="toggleColumn(col)"
-                >
-                  <span v-if="!hiddenColumns.has(col)" class="i-carbon-checkmark text-primary flex-shrink-0 h-3 w-3" />
-                  <span v-else class="flex-shrink-0 w-3 inline-block" />
-                  <span class="truncate">{{ col }}</span>
-                </button>
-              </div>
+        <!-- Column visibility dropdown -->
+        <div class="flex-shrink-0 relative">
+          <Button
+            variant="ghost"
+            size="icon"
+            class="h-7 w-7"
+            :title="t('components.dataTableView.columns')"
+            @click.stop="showColumnMenu = !showColumnMenu"
+          >
+            <span class="i-carbon-table-split h-3.5 w-3.5" />
+          </Button>
+
+          <div
+            v-if="showColumnMenu && data && data.columns.length > 0"
+            class="text-popover-foreground mt-1 border rounded-md bg-popover max-h-64 min-w-36 shadow-md right-0 top-full absolute z-50 overflow-auto"
+            @click.stop
+          >
+            <div class="text-xs text-muted-foreground font-semibold p-1 px-2 py-1.5 border-b">
+              {{ t('components.dataTableView.columns') }}
+            </div>
+            <div class="p-1">
+              <button
+                v-for="col in data.columns"
+                :key="col"
+                class="text-sm px-2 py-1 text-left rounded flex gap-2 w-full cursor-pointer items-center hover:bg-accent"
+                @click="toggleColumn(col)"
+              >
+                <span v-if="!hiddenColumns.has(col)" class="i-carbon-checkmark text-primary flex-shrink-0 h-3 w-3" />
+                <span v-else class="flex-shrink-0 w-3 inline-block" />
+                <span class="truncate">{{ col }}</span>
+              </button>
             </div>
           </div>
-        </Button>
+        </div>
 
         <!-- Delete Selected button -->
         <Button

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -902,15 +902,14 @@ watch(
 
         <!-- Refresh button -->
         <Button
-          variant="outline"
-          size="sm"
-          class="flex-shrink-0 h-7 gap-1 px-2"
+          variant="ghost"
+          size="icon"
+          class="flex-shrink-0 h-7 w-7"
           :disabled="loading"
           :title="t('components.dataTableView.refresh')"
           @click.stop="refresh"
         >
-          <span class="i-carbon-refresh h-3.5 w-3.5" :class="{ 'animate-spin': loading }" />
-          <span class="text-xs">{{ t('components.dataTableView.refresh') }}</span>
+          <span class="i-carbon-renew h-3.5 w-3.5" :class="{ 'animate-spin': loading }" />
           <!-- Column visibility dropdown -->
           <div class="flex-shrink-0 relative">
             <Button
@@ -995,7 +994,7 @@ watch(
               {{ connectionError }}
             </p>
             <Button size="sm" @click="handleRetry">
-              <span class="i-carbon-refresh mr-1.5 h-3.5 w-3.5" />
+              <span class="i-carbon-renew mr-1.5 h-3.5 w-3.5" />
               {{ t('components.dataTableView.reconnect') }}
             </Button>
           </div>

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -893,7 +893,7 @@ watch(
 
         <!-- Refresh button -->
         <Button
-          variant="outline"
+          variant="ghost"
           size="icon"
           class="flex-shrink-0 h-7 w-7"
           :disabled="loading"

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -902,7 +902,7 @@ watch(
 
         <!-- Refresh button -->
         <Button
-          variant="ghost"
+          variant="outline"
           size="icon"
           class="flex-shrink-0 h-7 w-7"
           :disabled="loading"

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -841,16 +841,15 @@ watch(
 
     <!-- Data sub-page: Toolbar bar (search + filter + actions) -->
     <template v-if="activeSubPage === 'data'">
-      <div class="px-3 py-1.5 border-b bg-muted/20 flex shrink-0 gap-1.5 items-center">
-        <span class="i-carbon-search text-muted-foreground flex-shrink-0 h-3.5 w-3.5" />
-
+      <div class="px-3 py-1.5 border-b bg-muted/20 flex shrink-0 gap-1 items-center">
         <!-- Search input — searches across all columns -->
         <div class="flex-1 min-w-0 relative">
+          <span class="i-carbon-search text-muted-foreground absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 pointer-events-none" />
           <Input
             ref="searchInputRef"
             v-model="searchTerm"
             :placeholder="t('components.dataTableView.searchPlaceholder')"
-            class="text-xs pr-7 flex-1 h-7"
+            class="text-xs pl-7 pr-7 h-7"
             @keydown="onSearchKeydown"
             @focus="onSearchFocus"
           />
@@ -861,44 +860,36 @@ watch(
           >
             <span class="i-carbon-loading h-3.5 w-3.5 animate-spin" />
           </div>
+          <!-- Clear search button (inside input, on the right) -->
+          <button
+            v-if="searchTerm"
+            class="text-muted-foreground right-1 top-1/2 absolute -translate-y-1/2 flex items-center justify-center h-5 w-5 rounded hover:bg-accent"
+            :title="t('components.dataTableView.clearSearch')"
+            @click.stop="clearSearch"
+          >
+            <span class="i-carbon-close h-3 w-3" />
+          </button>
         </div>
 
-        <!-- Clear search button -->
-        <Button
-          v-if="searchTerm"
-          variant="ghost"
-          size="icon"
-          class="flex-shrink-0 h-7 w-7"
-          :title="t('components.dataTableView.clearSearch')"
-          @click.stop="clearSearch"
-        >
-          <span class="i-carbon-close h-3.5 w-3.5" />
-        </Button>
-
-        <!-- Visual separator between search and filter sections -->
-        <div class="mx-0.5 bg-border flex-shrink-0 h-5 w-px" />
-
-        <span class="i-carbon-filter text-muted-foreground flex-shrink-0 h-3.5 w-3.5" />
-
         <!-- Filter input -->
-        <Input
-          v-model="filterInput"
-          :placeholder="t('components.dataTableView.filterPlaceholder')"
-          class="text-xs font-mono flex-1 h-7"
-          @keydown.enter="applyFilter"
-        />
-
-        <!-- Clear filter button -->
-        <Button
-          v-if="filterInput || appliedFilter"
-          variant="ghost"
-          size="icon"
-          class="flex-shrink-0 h-7 w-7"
-          :title="t('components.dataTableView.clearFilter')"
-          @click.stop="clearFilter"
-        >
-          <span class="i-carbon-close h-3.5 w-3.5" />
-        </Button>
+        <div class="flex-1 min-w-0 relative">
+          <span class="i-carbon-filter text-muted-foreground absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 pointer-events-none" />
+          <Input
+            v-model="filterInput"
+            :placeholder="t('components.dataTableView.filterPlaceholder')"
+            class="text-xs font-mono pl-7 h-7"
+            @keydown.enter="applyFilter"
+          />
+          <!-- Clear filter button (inside input, on the right) -->
+          <button
+            v-if="filterInput || appliedFilter"
+            class="text-muted-foreground right-1 top-1/2 absolute -translate-y-1/2 flex items-center justify-center h-5 w-5 rounded hover:bg-accent"
+            :title="t('components.dataTableView.clearFilter')"
+            @click.stop="clearFilter"
+          >
+            <span class="i-carbon-close h-3 w-3" />
+          </button>
+        </div>
 
         <!-- Refresh button -->
         <Button

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -902,14 +902,15 @@ watch(
 
         <!-- Refresh button -->
         <Button
-          variant="ghost"
-          size="icon"
-          class="flex-shrink-0 h-7 w-7"
+          variant="outline"
+          size="sm"
+          class="flex-shrink-0 h-7 gap-1 px-2"
           :disabled="loading"
           :title="t('components.dataTableView.refresh')"
           @click.stop="refresh"
         >
           <span class="i-carbon-refresh h-3.5 w-3.5" :class="{ 'animate-spin': loading }" />
+          <span class="text-xs">{{ t('components.dataTableView.refresh') }}</span>
           <!-- Column visibility dropdown -->
           <div class="flex-shrink-0 relative">
             <Button

--- a/src/composables/useSqlStatements.ts
+++ b/src/composables/useSqlStatements.ts
@@ -322,49 +322,84 @@ function splitRangesAtBlankLines(ranges: StatementRange[], content: string): Sta
 
     let blankRun = 0
     let seenContent = false
-    const splitLineIndices: number[] = []
+    let inBlockComment = false
+    // Track the line index of the last actual SQL content (for split boundaries)
+    let lastContentLine = -1
+    // When the segment starts with `WITH`, suppress soft-split for the next DML
+    // keyword — it's the main query of a CTE, not a new statement.
+    let segmentFirstKeyword: string | null = null
+    const FIRST_DML_KEYWORDS = new Set(['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'MERGE', 'REPLACE'])
+    // Each split: { sqlLine: the SQL keyword line, prevContentLine: last content before blank run }
+    const splits: { sqlLine: number, prevContentLine: number }[] = []
 
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim()
 
+      // Lines inside a multi-line block comment — skip without resetting blankRun
+      if (inBlockComment) {
+        if (trimmed.endsWith('*/'))
+          inBlockComment = false
+        continue
+      }
+
       if (trimmed.length === 0) {
         if (seenContent)
           blankRun++
+        continue
       }
-      else {
-        if (!seenContent) {
-          seenContent = true
-        }
-        else if (blankRun >= 2) {
-          const firstWord = trimmed.split(/\s+/)[0]?.toUpperCase()
-          if (firstWord && SOFT_STATEMENT_KEYWORDS.has(firstWord))
-            splitLineIndices.push(i)
-        }
-        blankRun = 0
+
+      // Comment-only lines should not reset the blank-run counter,
+      // so that `SELECT ...\n\n\n-- comment\nSELECT ...` still splits.
+      if (trimmed.startsWith('--') || trimmed.startsWith('#')) {
+        continue
       }
+      if (trimmed.startsWith('/*')) {
+        if (!trimmed.endsWith('*/'))
+          inBlockComment = true
+        continue
+      }
+
+      // Actual SQL content
+      const firstWord = trimmed.split(/\s+/)[0]?.toUpperCase()
+      if (!seenContent) {
+        seenContent = true
+        segmentFirstKeyword = firstWord ?? null
+      }
+      else if (blankRun >= 2 && firstWord && SOFT_STATEMENT_KEYWORDS.has(firstWord)) {
+        // When the segment starts with WITH, the next DML keyword is the main
+        // query of the CTE (e.g. `WITH cte AS (...) \n\n\n SELECT ...`).
+        // Splitting there would orphan the CTE definition.
+        const isCteMainQuery = segmentFirstKeyword === 'WITH' && firstWord && FIRST_DML_KEYWORDS.has(firstWord)
+        if (!isCteMainQuery)
+          splits.push({ sqlLine: i, prevContentLine: lastContentLine })
+      }
+      blankRun = 0
+      lastContentLine = i
     }
 
-    if (splitLineIndices.length === 0) {
+    if (splits.length === 0) {
       result.push(range)
       continue
     }
 
-    let prevIdx = 0
-    for (const splitIdx of splitLineIndices) {
-      const segStart = range.startOffset + lineOffsets[prevIdx]
-      const segEnd = range.startOffset + lineOffsets[splitIdx]
-      // Trim trailing whitespace so the preceding range ends at its last content
-      const segText = content.slice(segStart, segEnd).trimEnd()
-      if (segText.length > 0)
-        result.push(buildRange(content, segStart, segStart + segText.length))
-      prevIdx = splitIdx
+    // Build sub-ranges. Each preceding segment ends at its last content line
+    // (excluding trailing blank/comment lines). Each new segment starts at the
+    // SQL keyword line in `splits[].sqlLine`.
+    let segStart = range.startOffset + lineOffsets[0]
+
+    for (const { sqlLine, prevContentLine } of splits) {
+      // End the preceding segment right after `prevContentLine`
+      const segEnd = range.startOffset + lineOffsets[prevContentLine] + lines[prevContentLine].length
+      result.push(buildRange(content, segStart, segEnd))
+      segStart = range.startOffset + lineOffsets[sqlLine]
     }
-    // Trim leading whitespace on the final segment
-    const lastStart = range.startOffset + lineOffsets[prevIdx]
-    const lastText = content.slice(lastStart, range.endOffset).trimStart()
-    if (lastText.length > 0) {
-      const trimmed = lastText.length - lastText.trimStart().length
-      result.push(buildRange(content, lastStart + trimmed, range.endOffset))
+
+    // Final segment (trim leading whitespace)
+    const rawFinal = content.slice(segStart, range.endOffset)
+    const finalTrimmed = rawFinal.trimStart()
+    if (finalTrimmed.length > 0) {
+      const skipped = rawFinal.length - finalTrimmed.length
+      result.push(buildRange(content, segStart + skipped, range.endOffset))
     }
   }
 

--- a/src/composables/useSqlStatements.ts
+++ b/src/composables/useSqlStatements.ts
@@ -265,8 +265,115 @@ function skipLeadingComments(text: string): number {
   return skipped
 }
 
+// Keywords that can signal a new statement start after 2+ blank lines
+// (when a `;` was forgotten). Covers DML, DDL, TCL, and utility commands.
+const SOFT_STATEMENT_KEYWORDS = new Set([
+  'SELECT',
+  'CREATE',
+  'ALTER',
+  'DROP',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'TRUNCATE',
+  'GRANT',
+  'REVOKE',
+  'EXPLAIN',
+  'SHOW',
+  'DESCRIBE',
+  'USE',
+  'SET',
+  'CALL',
+  'EXEC',
+  'EXECUTE',
+  'BEGIN',
+  'COMMIT',
+  'ROLLBACK',
+  'DECLARE',
+  'ANALYZE',
+  'VACUUM',
+  'PRAGMA',
+  'REFRESH',
+  'COPY',
+  'WITH',
+  'MERGE',
+  'REPLACE',
+])
+
+/**
+ * After splitting by `;`, scan each range for 2+ consecutive blank lines
+ * followed by a SQL keyword. When found, split the range there — this
+ * recovers from missing `;` between statements separated by blank lines.
+ */
+function splitRangesAtBlankLines(ranges: StatementRange[], content: string): StatementRange[] {
+  const result: StatementRange[] = []
+
+  for (const range of ranges) {
+    const text = content.slice(range.startOffset, range.endOffset)
+    const lines = text.split('\n')
+
+    // Pre-compute each line's byte offset within `text`
+    const lineOffsets: number[] = []
+    let off = 0
+    for (const line of lines) {
+      lineOffsets.push(off)
+      off += line.length + 1 // +1 for \n
+    }
+
+    let blankRun = 0
+    let seenContent = false
+    const splitLineIndices: number[] = []
+
+    for (let i = 0; i < lines.length; i++) {
+      const trimmed = lines[i].trim()
+
+      if (trimmed.length === 0) {
+        if (seenContent)
+          blankRun++
+      }
+      else {
+        if (!seenContent) {
+          seenContent = true
+        }
+        else if (blankRun >= 2) {
+          const firstWord = trimmed.split(/\s+/)[0]?.toUpperCase()
+          if (firstWord && SOFT_STATEMENT_KEYWORDS.has(firstWord))
+            splitLineIndices.push(i)
+        }
+        blankRun = 0
+      }
+    }
+
+    if (splitLineIndices.length === 0) {
+      result.push(range)
+      continue
+    }
+
+    let prevIdx = 0
+    for (const splitIdx of splitLineIndices) {
+      const segStart = range.startOffset + lineOffsets[prevIdx]
+      const segEnd = range.startOffset + lineOffsets[splitIdx]
+      // Trim trailing whitespace so the preceding range ends at its last content
+      const segText = content.slice(segStart, segEnd).trimEnd()
+      if (segText.length > 0)
+        result.push(buildRange(content, segStart, segStart + segText.length))
+      prevIdx = splitIdx
+    }
+    // Trim leading whitespace on the final segment
+    const lastStart = range.startOffset + lineOffsets[prevIdx]
+    const lastText = content.slice(lastStart, range.endOffset).trimStart()
+    if (lastText.length > 0) {
+      const trimmed = lastText.length - lastText.trimStart().length
+      result.push(buildRange(content, lastStart + trimmed, range.endOffset))
+    }
+  }
+
+  return result.filter(r => r.text.trim().length > 0)
+}
+
 export function parseSqlStatements(content: string): SqlStatement[] {
-  const ranges = scanStatements(content)
+  const rawRanges = scanStatements(content)
+  const ranges = splitRangesAtBlankLines(rawRanges, content)
   const lines = content.split('\n')
 
   return ranges

--- a/tests/composables/useSqlStatements.test.ts
+++ b/tests/composables/useSqlStatements.test.ts
@@ -162,6 +162,79 @@ describe('parseSqlStatements', () => {
     })
   })
 
+  describe('soft split at blank lines (missing semicolon)', () => {
+    it('splits two statements separated by 2 blank lines', () => {
+      const sql = [
+        'SELECT 1', // line 1
+        '', // line 2 (blank)
+        '', // line 3 (blank)
+        'SELECT 2', // line 4
+      ].join('\n')
+
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(2)
+      expect(result[0].statement).toBe('SELECT 1')
+      expect(result[1].statement).toBe('SELECT 2')
+    })
+
+    it('does not split on only 1 blank line', () => {
+      const sql = 'SELECT 1\n\nSELECT 2'
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(1)
+      expect(result[0].statement).toContain('SELECT 1')
+      expect(result[0].statement).toContain('SELECT 2')
+    })
+
+    it('splits 3 statements separated by 2 blank lines each', () => {
+      const sql = [
+        'SELECT 1', // line 1
+        '', // line 2
+        '', // line 3
+        'SELECT 2', // line 4
+        '', // line 5
+        '', // line 6
+        'SELECT 3', // line 7
+      ].join('\n')
+
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(3)
+      expect(result[0].statement).toBe('SELECT 1')
+      expect(result[1].statement).toBe('SELECT 2')
+      expect(result[2].statement).toBe('SELECT 3')
+    })
+
+    it('does not split when next line after 2 blanks is not a SQL keyword', () => {
+      const sql = [
+        'SELECT 1', // line 1
+        '', // line 2
+        '', // line 3
+        '  some_column', // line 4 (not a keyword)
+      ].join('\n')
+
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(1)
+    })
+
+    it('sets correct positions for soft-split statements', () => {
+      const sql = 'SELECT 1\n\n\nSELECT 2'
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(2)
+      expect(result[0].position.startLineNumber).toBe(1)
+      expect(result[0].position.endLineNumber).toBe(1)
+      expect(result[1].position.startLineNumber).toBe(4)
+      expect(result[1].position.endLineNumber).toBe(4)
+    })
+
+    it('handles mixed ; and blank-line splits', () => {
+      const sql = 'SELECT 1;\nSELECT 2\n\n\nSELECT 3'
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(3)
+      expect(result[0].statement).toBe('SELECT 1')
+      expect(result[1].statement).toBe('SELECT 2')
+      expect(result[2].statement).toBe('SELECT 3')
+    })
+  })
+
   describe('nested parens (subqueries)', () => {
     it('does not split on SELECT inside a subquery', () => {
       const sql = [

--- a/tests/composables/useSqlStatements.test.ts
+++ b/tests/composables/useSqlStatements.test.ts
@@ -215,6 +215,56 @@ describe('parseSqlStatements', () => {
       expect(result).toHaveLength(1)
     })
 
+    it('splits when 2 blank lines are followed by a comment then SQL keyword', () => {
+      const sql = [
+        'SELECT 1', // line 1
+        '', // line 2
+        '', // line 3
+        '', // line 4
+        '-- comment', // line 5
+        'SELECT 2', // line 6
+      ].join('\n')
+
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(2)
+      expect(result[0].statement).toBe('SELECT 1')
+      expect(result[1].statement).toBe('SELECT 2')
+      expect(result[1].position.startLineNumber).toBe(6)
+    })
+
+    it('does not split CTE with blank lines before main SELECT', () => {
+      const sql = [
+        'WITH cte AS (', // line 1
+        '  SELECT 1', // line 2
+        ')', // line 3
+        '', // line 4
+        '', // line 5
+        'SELECT * FROM cte', // line 6
+      ].join('\n')
+
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(1)
+      expect(result[0].statement).toContain('WITH cte AS')
+      expect(result[0].statement).toContain('SELECT * FROM cte')
+    })
+
+    it('does not split CTE INSERT with blank lines before INSERT', () => {
+      const sql = [
+        'WITH cte AS (', // line 1
+        '  SELECT 1', // line 2
+        ')', // line 3
+        '', // line 4
+        '', // line 5
+        'INSERT INTO t', // line 6
+        'SELECT * FROM cte', // line 7
+      ].join('\n')
+
+      const result = parseSqlStatements(sql)
+      expect(result).toHaveLength(1)
+      expect(result[0].statement).toContain('WITH cte AS')
+      expect(result[0].statement).toContain('INSERT INTO t')
+    })
+
     it('sets correct positions for soft-split statements', () => {
       const sql = 'SELECT 1\n\n\nSELECT 2'
       const result = parseSqlStatements(sql)


### PR DESCRIPTION
## Changes

### 1. Soft-split SQL statements at blank lines (当 `;` 忘记时自动分割)

Added `splitRangesAtBlankLines()` that runs after the standard `;`-based split. When 2+ consecutive blank lines are followed by a SQL keyword, the range is split at that point.

**Split keywords**: SELECT, CREATE, ALTER, DROP, INSERT, UPDATE, DELETE, TRUNCATE, GRANT, REVOKE, EXPLAIN, SHOW, DESCRIBE, USE, SET, CALL, EXEC/EXECUTE, BEGIN, COMMIT, ROLLBACK, DECLARE, ANALYZE, VACUUM, PRAGMA, REFRESH, COPY, WITH, MERGE, REPLACE

**Safety**: Requires 2+ blank lines (not 1) — a single blank line within a multi-line statement won't split it.

**CTE protection**: When the segment starts with `WITH`, suppresses soft-split for the next DML keyword (SELECT/INSERT/UPDATE/DELETE) since it's the main query of a CTE, not a new statement.

### 2. Table view toolbar fixes

- **Fixed refresh icon**: `i-carbon-refresh` does not exist in Carbon icons → changed to `i-carbon-renew` (same icon as "Reload database list")
- **Fixed nested button bug**: Refresh button was wrapping the columns dropdown (`<button>` inside `<button>`) — properly separated
- **Icons inside inputs**: Search and filter icons moved from outside to inside the input boxes (absolute positioned), saving toolbar space
- **Removed separator**: Visual separator between search and filter removed (no longer needed)
- **Consistent style**: Refresh button uses `variant="ghost"` like other toolbar icon buttons

### 3. Export filename format

Default CSV export filename changed from `{tableName}.csv` to `{connectionName}-{databaseName}-{schema?}-{tableName}-{timestamp}.csv`

## Verification

- 455 tests pass (no regressions)
- 9 new test cases for blank-line splitting including CTE protection
- Lint clean