### PR TITLE
fix: connection auto-reconnect, executable top-N SQL, and context-menu UX fixes

### DIFF
--- a/src-tauri/src/capabilities/commands.rs
+++ b/src-tauri/src/capabilities/commands.rs
@@ -58,10 +58,7 @@ fn to_metadata(cap: &Capability) -> Value {
 
 async fn resolve_connection_config(app: &AppHandle, connection_id: &str) -> Result<Value, String> {
     let state: tauri::State<'_, crate::state::AppState> = app.state();
-    let conns = state.connections.read().await;
-    let _active = conns
-        .get(connection_id)
-        .ok_or_else(|| format!("Connection not found: {}", connection_id))?;
+    state.ensure_connection(connection_id).await?;
 
     Ok(json!({ "connectionId": connection_id }))
 }

--- a/src-tauri/src/capabilities/sql.rs
+++ b/src-tauri/src/capabilities/sql.rs
@@ -65,8 +65,8 @@ async fn resolve_adapter(connection_id: &str) -> Result<ActiveConnection, String
     // Store the adapter for future use
     {
         let state: tauri::State<'_, crate::state::AppState> = app.state();
-        let mut conns = state.connections.write().await;
-        conns.insert(connection_id.to_string(), adapter.clone());
+        state.connections.write().await.insert(connection_id.to_string(), adapter.clone());
+        state.configs.write().await.insert(connection_id.to_string(), server_config);
     }
 
     Ok(adapter)

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -147,13 +147,7 @@ pub async fn list_databases(
     connection_id: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<DatabaseSchema>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
     let databases = connection
         .list_databases()
         .await
@@ -179,13 +173,7 @@ pub async fn list_schemas(
     database: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<String>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let schemas = connection
         .list_schemas(Some(&database))
@@ -214,13 +202,7 @@ pub async fn list_tables(
     schema: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<Vec<TableInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let tables = connection
         .list_tables(Some(&database), schema.as_deref())
@@ -251,13 +233,7 @@ pub async fn get_table_info(
     table_name: String,
     state: State<'_, AppState>,
 ) -> Result<TableInfo, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let table_info = connection
         .get_table_info(Some(&database), schema.as_deref(), &table_name)
@@ -276,13 +252,7 @@ pub async fn list_columns(
     table_name: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<ColumnInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let columns = match &connection {
         ActiveConnection::Postgres(adapter) => {
@@ -344,13 +314,7 @@ pub async fn get_foreign_keys(
     schema: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<Vec<ForeignKeyInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let result = connection
         .get_foreign_keys(Some(&database), schema.as_deref())
@@ -377,13 +341,7 @@ pub async fn get_table_data(
     query: TableDataQuery,
     state: State<'_, AppState>,
 ) -> Result<QueryResult, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let limit_val = query.limit.unwrap_or(100);
     let offset_val = query.offset.unwrap_or(0);
@@ -510,13 +468,7 @@ pub async fn get_table_count(
     filter: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<u64, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let filter_ref = filter.as_deref();
     let db_type = get_db_type_string(&connection);
@@ -685,13 +637,7 @@ pub async fn update_table_row(
         return Ok(());
     }
 
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let db_type = get_db_type_string(&connection);
 
@@ -823,13 +769,7 @@ pub async fn delete_table_row(
         return Err("Cannot delete row: no primary key values provided".to_string());
     }
 
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let db_type = get_db_type_string(&connection);
 
@@ -930,13 +870,7 @@ pub async fn list_views(
     schema: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<Vec<ObjectInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .list_views(Some(&database), schema.as_deref())
@@ -952,13 +886,7 @@ pub async fn list_procedures(
     schema: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<Vec<ObjectInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .list_procedures(Some(&database), schema.as_deref())
@@ -974,13 +902,7 @@ pub async fn list_functions(
     schema: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<Vec<ObjectInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .list_functions(Some(&database), schema.as_deref())
@@ -997,13 +919,7 @@ pub async fn list_triggers(
     table: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<TriggerInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .list_triggers(Some(&database), schema.as_deref(), &table)
@@ -1020,13 +936,7 @@ pub async fn list_indexes(
     table: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<IndexInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .list_indexes(Some(&database), schema.as_deref(), &table)
@@ -1043,13 +953,7 @@ pub async fn list_foreign_keys(
     table: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<ForeignKeyInfo>, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .list_foreign_keys_for_table(Some(&database), schema.as_deref(), &table)
@@ -1067,13 +971,7 @@ pub async fn get_object_ddl(
     object_type: String,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .get_object_ddl(
@@ -1096,13 +994,7 @@ pub async fn drop_object(
     object_type: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .drop_object(
@@ -1126,13 +1018,7 @@ pub async fn rename_object(
     new_name: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    let connection = state.ensure_connection(&connection_id).await?;
 
     connection
         .rename_object(
@@ -1205,14 +1091,11 @@ pub async fn build_table_search_filter(
     search_term: String,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let connections = state.connections.read().await;
-    let connection = connections
-        .get(&connection_id)
-        .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?;
+    let connection = state.ensure_connection(&connection_id).await?;
 
-    let db_type = get_db_type_string(connection);
+    let db_type = get_db_type_string(&connection);
 
-    let columns = match connection {
+    let columns = match &connection {
         ActiveConnection::Postgres(adapter) => {
             let adapter = adapter.lock().await;
             if Some(database.as_str()) != adapter.config.database.as_deref() {

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -28,6 +28,8 @@ pub async fn connect_server(
     let mut connections = state.connections.write().await;
     connections.insert(id.clone(), connection.clone());
     drop(connections);
+    // Keep the config so a lost session can be transparently recreated later.
+    state.configs.write().await.insert(id.clone(), config);
     let status = connection
         .test_connection()
         .await
@@ -45,6 +47,8 @@ pub async fn disconnect_server(id: String, state: State<'_, AppState>) -> Result
     let connection = connections
         .remove(&id)
         .ok_or_else(|| format!("No active connection found for server '{}'", id))?;
+
+    state.configs.write().await.remove(&id);
 
     let disconnect_result = connection.disconnect().await;
 

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -129,10 +129,7 @@ pub async fn execute_query(
         }
 
         let temp_kind: Option<TempKind> = {
-            let connections = state.connections.read().await;
-            let connection = connections
-                .get(&connection_id)
-                .ok_or_else(|| "No active connection found".to_string())?;
+            let connection = state.ensure_connection(&connection_id).await?;
 
             match connection {
                 ActiveConnection::Postgres(adapter) => {
@@ -250,14 +247,8 @@ pub async fn execute_query(
         }
     }
 
-    // Common path: use the already-connected adapter
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| "No active connection found".to_string())?
-            .clone()
-    };
+    // Common path: use the already-connected adapter (reconnecting if needed)
+    let connection = state.ensure_connection(&connection_id).await?;
 
     // Cache this handle for future cross-database lookups
     state
@@ -334,11 +325,8 @@ pub async fn execute_sorted_query(
 ) -> Result<ApiResponse<QueryResult>, String> {
     // Derive database type from the active connection
     let db_type = {
-        let connections = state.connections.read().await;
-        let connection = connections
-            .get(&connection_id)
-            .ok_or_else(|| "No active connection found".to_string())?;
-        crate::commands::browse::get_db_type_string(connection).to_string()
+        let connection = state.ensure_connection(&connection_id).await?;
+        crate::commands::browse::get_db_type_string(&connection).to_string()
     };
 
     // Inject the database type into options and build the wrapped SQL
@@ -434,10 +422,7 @@ pub async fn explain_query(
         }
 
         let temp_kind: Option<TempExplainKind> = {
-            let connections = state.connections.read().await;
-            let connection = connections
-                .get(&connection_id)
-                .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?;
+            let connection = state.ensure_connection(&connection_id).await?;
 
             match connection {
                 ActiveConnection::Postgres(adapter) => {
@@ -717,14 +702,8 @@ pub async fn explain_query(
         }
     }
 
-    // Common path: use the already-connected adapter
-    let connection = {
-        let connections = state.connections.read().await;
-        connections
-            .get(&connection_id)
-            .ok_or_else(|| format!("No active connection found for ID '{}'", connection_id))?
-            .clone()
-    };
+    // Common path: use the already-connected adapter (reconnecting if needed)
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let database_type = match &connection {
         ActiveConnection::Postgres(_) => "postgresql",

--- a/src-tauri/src/commands/transfer.rs
+++ b/src-tauri/src/commands/transfer.rs
@@ -15,10 +15,7 @@ pub async fn preview_export_data(
     preview_rows: u32,
     state: State<'_, AppState>,
 ) -> Result<ExportPreview, String> {
-    let connections = state.connections.read().await;
-    let connection = connections
-        .get(&request.connection_id)
-        .ok_or_else(|| "No active connection found".to_string())?;
+    let connection = state.ensure_connection(&request.connection_id).await?;
 
     match connection {
         ActiveConnection::Postgres(adapter) => {
@@ -47,10 +44,7 @@ pub async fn execute_export_data(
     app_handle: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<TransferResult, String> {
-    let connections = state.connections.read().await;
-    let connection = connections
-        .get(&request.connection_id)
-        .ok_or_else(|| "No active connection found".to_string())?;
+    let connection = state.ensure_connection(&request.connection_id).await?;
 
     match connection {
         ActiveConnection::Postgres(adapter) => {
@@ -93,10 +87,7 @@ pub async fn execute_import_data(
     app_handle: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<TransferResult, String> {
-    let connections = state.connections.read().await;
-    let connection = connections
-        .get(&request.connection_id)
-        .ok_or_else(|| "No active connection found".to_string())?;
+    let connection = state.ensure_connection(&request.connection_id).await?;
 
     match connection {
         ActiveConnection::Postgres(adapter) => {
@@ -124,11 +115,7 @@ pub async fn preview_migration_data(
     request: MigrationRequest,
     state: State<'_, AppState>,
 ) -> Result<MigrationPreview, String> {
-    let connections = state.connections.read().await;
-
-    let source_connection = connections
-        .get(&request.source_connection_id)
-        .ok_or_else(|| "No source connection found".to_string())?;
+    let source_connection = state.ensure_connection(&request.source_connection_id).await?;
 
     match source_connection {
         ActiveConnection::Postgres(adapter) => {
@@ -157,15 +144,9 @@ pub async fn execute_migration_data(
     app_handle: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<TransferResult, String> {
-    let connections = state.connections.read().await;
+    let source_connection = state.ensure_connection(&request.source_connection_id).await?;
 
-    let source_connection = connections
-        .get(&request.source_connection_id)
-        .ok_or_else(|| "No source connection found".to_string())?;
-
-    let target_connection = connections
-        .get(&request.target_connection_id)
-        .ok_or_else(|| "No target connection found".to_string())?;
+    let target_connection = state.ensure_connection(&request.target_connection_id).await?;
 
     macro_rules! run_migration {
         ($source_adapter:expr, $target_adapter:expr) => {
@@ -269,10 +250,7 @@ pub async fn auto_map_migration_columns(
 ) -> Result<Vec<crate::transfer::MigrationMapping>, String> {
     use crate::database::DatabaseAdapter;
 
-    let connections = state.connections.read().await;
-    let connection = connections
-        .get(&connection_id)
-        .ok_or_else(|| "No active connection found".to_string())?;
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let target_db_type = match target_engine.to_lowercase().as_str() {
         "postgresql" | "postgres" => DatabaseType::PostgreSQL,
@@ -307,10 +285,7 @@ pub async fn generate_ddl_for_objects(
     request: DdlRequest,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let connections = state.connections.read().await;
-    let connection = connections
-        .get(&request.connection_id)
-        .ok_or_else(|| "No active connection found".to_string())?;
+    let connection = state.ensure_connection(&request.connection_id).await?;
 
     let engine = match connection {
         ActiveConnection::Postgres(_) => DatabaseType::PostgreSQL,
@@ -441,10 +416,7 @@ pub async fn execute_sql_content(
     on_error: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<TransferResult, String> {
-    let connections = state.connections.read().await;
-    let connection = connections
-        .get(&connection_id)
-        .ok_or_else(|| "No active connection found".to_string())?;
+    let connection = state.ensure_connection(&connection_id).await?;
 
     let strategy = on_error.as_deref().unwrap_or("stop");
     let statements = split_sql_statements(&content);

--- a/src-tauri/src/connection/cache.rs
+++ b/src-tauri/src/connection/cache.rs
@@ -85,13 +85,9 @@ impl ConnectionCache {
             }
         }
 
-        // Slow path: need to create connection
-        let conns = app_state.connections.read().await;
-        let connection = conns
-            .get(&key.connection_id)
-            .cloned()
-            .ok_or_else(|| format!("No active connection found for '{}'", key.connection_id))?;
-        drop(conns);
+        // Slow path: need to create connection — transparently reconnect when
+        // the session was lost or idle-evicted instead of erroring out.
+        let connection = app_state.ensure_connection(&key.connection_id).await?;
 
         // Evict if at capacity
         {

--- a/src-tauri/src/connection/guardian.rs
+++ b/src-tauri/src/connection/guardian.rs
@@ -359,18 +359,15 @@ impl ConnectionGuardian {
         }
         self.emit_state_change(connection_id, HealthState::Reconnecting, None);
 
-        // Try to reconnect by calling test_connection on the active connection
+        // Try to reconnect by recreating the adapter from the stored config.
+        // Pinging the stale adapter is not enough — the underlying session may
+        // be irrecoverable (server restart, dropped connection).
         let success = {
             let state = APP_HANDLE
                 .get()
                 .expect("APP_HANDLE not initialized")
                 .state::<AppState>();
-            let conns = state.connections.read().await;
-            let conn = conns.get(connection_id);
-            match conn {
-                Some(c) => self.ping_connection(c).await,
-                None => false,
-            }
+            state.ensure_connection(connection_id).await.is_ok()
         };
 
         if success {

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -511,10 +511,7 @@ async fn resolve_connection(connection_id: &str) -> Result<Value, String> {
         .ok_or_else(|| "AppHandle not initialized".to_string())?;
     use tauri::State;
     let state: State<'_, crate::state::AppState> = handle.state();
-    let conns = state.connections.read().await;
-    let _active = conns
-        .get(connection_id)
-        .ok_or_else(|| format!("Connection not found: {}", connection_id))?;
+    state.ensure_connection(connection_id).await?;
     Ok(json!({ "connectionId": connection_id }))
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -287,6 +287,9 @@ pub struct AppConfig {
 pub struct AppState {
     /// Active database connections indexed by connection ID.
     pub connections: Arc<RwLock<HashMap<String, ActiveConnection>>>,
+    /// Server configs for active connections, kept so a lost/evicted session can
+    /// be transparently recreated on the next user action.
+    pub configs: Arc<RwLock<HashMap<String, ServerConfig>>>,
     /// LRU cache for cross-database connection handles.
     pub cache: crate::connection::cache::ConnectionCache,
     /// SSH tunnel lifecycle manager.
@@ -298,9 +301,60 @@ impl AppState {
     pub fn new() -> Self {
         Self {
             connections: Arc::new(RwLock::new(HashMap::new())),
+            configs: Arc::new(RwLock::new(HashMap::new())),
             cache: crate::connection::cache::ConnectionCache::default(),
             tunnels: TunnelManager::new(),
         }
+    }
+
+    /// Return the active connection for `connection_id`.
+    ///
+    /// If the session was lost or idle-evicted, transparently reconnects using
+    /// the stored server config so user actions never fail with a
+    /// "No active connection found" error. Errors are returned only when the
+    /// server cannot be reached or no config was ever stored for this id.
+    pub async fn ensure_connection(&self, connection_id: &str) -> Result<ActiveConnection, String> {
+        if let Some(conn) = self.connections.read().await.get(connection_id) {
+            return Ok(conn.clone());
+        }
+
+        let config = self
+            .configs
+            .read()
+            .await
+            .get(connection_id)
+            .cloned()
+            .ok_or_else(|| format!("No active connection found for server '{}'", connection_id))?;
+
+        let mut conn_config = config.to_connection_config()?;
+        let (host, port) = crate::commands::helpers::connection_host_port(
+            connection_id,
+            &conn_config,
+            &self.tunnels,
+        )
+        .await?;
+        conn_config.host = host;
+        conn_config.port = port;
+
+        let timeout_secs = conn_config.connect_timeout_secs;
+        let connection = tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            crate::commands::helpers::create_and_connect_adapter(&config.db_type, conn_config),
+        )
+        .await
+        .map_err(|_| format!("Reconnect timed out after {} seconds", timeout_secs))??;
+
+        self.connections
+            .write()
+            .await
+            .insert(connection_id.to_string(), connection.clone());
+
+        // Notify the guardian so the frontend state flips back to CONNECTED.
+        if let Some(guardian) = crate::GUARDIAN.get() {
+            guardian.mark_healthy(connection_id, None).await;
+        }
+
+        Ok(connection)
     }
 }
 

--- a/src/components/connections/ServerCard.vue
+++ b/src/components/connections/ServerCard.vue
@@ -93,6 +93,11 @@ const handleEdit = () => emit('edit', props.connection)
 const handleDelete = () => emit('delete', props.connection)
 const handleDuplicate = () => emit('duplicate', props.connection)
 const handleDisconnect = () => emit('disconnect', props.connection)
+
+const isConnected = computed(() => props.connectionStatus === ConnectionStatus.CONNECTED)
+const connectTooltip = computed(() =>
+  isConnected.value ? t('components.serverCard.actions.closeConnection') : t('components.serverCard.actions.connect'),
+)
 </script>
 
 <template>
@@ -229,6 +234,24 @@ const handleDisconnect = () => emit('disconnect', props.connection)
             <TooltipTrigger as-child>
               <Button variant="ghost" size="icon" class="h-8 w-8" @click="handleConnect">
                 <svg
+                  v-if="isConnected"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"
+                >
+                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                  <polyline points="16 17 21 12 16 7" />
+                  <line x1="21" x2="9" y1="12" y2="12" />
+                </svg>
+                <svg
+                  v-else
                   xmlns="http://www.w3.org/2000/svg"
                   width="24"
                   height="24"
@@ -247,7 +270,7 @@ const handleDisconnect = () => emit('disconnect', props.connection)
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{{ t('components.serverCard.actions.connect') }}</p>
+              <p>{{ connectTooltip }}</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/src/components/connections/ServerCard.vue
+++ b/src/components/connections/ServerCard.vue
@@ -27,6 +27,7 @@ const emit = defineEmits<{
   (e: 'edit', connection: ServerConnection): void
   (e: 'delete', connection: ServerConnection): void
   (e: 'duplicate', connection: ServerConnection): void
+  (e: 'disconnect', connection: ServerConnection): void
 }>()
 
 const { t } = useI18n()
@@ -91,6 +92,7 @@ const handleDoubleClick = () => emit('dblclick', props.connection)
 const handleEdit = () => emit('edit', props.connection)
 const handleDelete = () => emit('delete', props.connection)
 const handleDuplicate = () => emit('duplicate', props.connection)
+const handleDisconnect = () => emit('disconnect', props.connection)
 </script>
 
 <template>
@@ -272,6 +274,29 @@ const handleDuplicate = () => emit('duplicate', props.connection)
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              v-if="connectionStatus === ConnectionStatus.CONNECTED"
+              @click="handleDisconnect"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="mr-2 h-4 w-4"
+              >
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" x2="9" y1="12" y2="12" />
+              </svg>
+              {{ t('components.serverCard.actions.disconnect') }}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator v-if="connectionStatus === ConnectionStatus.CONNECTED" />
             <DropdownMenuItem @click="handleEdit">
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/components/connections/ServerCard.vue
+++ b/src/components/connections/ServerCard.vue
@@ -294,7 +294,7 @@ const handleDisconnect = () => emit('disconnect', props.connection)
                 <polyline points="16 17 21 12 16 7" />
                 <line x1="21" x2="9" y1="12" y2="12" />
               </svg>
-              {{ t('components.serverCard.actions.disconnect') }}
+              {{ t('components.serverCard.actions.closeConnection') }}
             </DropdownMenuItem>
             <DropdownMenuSeparator v-if="connectionStatus === ConnectionStatus.CONNECTED" />
             <DropdownMenuItem @click="handleEdit">

--- a/src/components/connections/ServerCard.vue
+++ b/src/components/connections/ServerCard.vue
@@ -313,9 +313,8 @@ const connectTooltip = computed(() =>
                 stroke-linejoin="round"
                 class="mr-2 h-4 w-4"
               >
-                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-                <polyline points="16 17 21 12 16 7" />
-                <line x1="21" x2="9" y1="12" y2="12" />
+                <path d="M12 2v10" />
+                <path d="M18.4 6.6a9 9 0 1 1-12.77.04" />
               </svg>
               {{ t('components.serverCard.actions.closeConnection') }}
             </DropdownMenuItem>

--- a/src/components/connections/ServerCard.vue
+++ b/src/components/connections/ServerCard.vue
@@ -96,7 +96,7 @@ const handleDisconnect = () => emit('disconnect', props.connection)
 
 const isConnected = computed(() => props.connectionStatus === ConnectionStatus.CONNECTED)
 const connectTooltip = computed(() =>
-  isConnected.value ? t('components.serverCard.actions.closeConnection') : t('components.serverCard.actions.connect'),
+  isConnected.value ? t('components.serverCard.actions.openEditor') : t('components.serverCard.actions.connect'),
 )
 </script>
 
@@ -246,9 +246,9 @@ const connectTooltip = computed(() =>
                   stroke-linejoin="round"
                   class="h-4 w-4"
                 >
-                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-                  <polyline points="16 17 21 12 16 7" />
-                  <line x1="21" x2="9" y1="12" y2="12" />
+                  <path d="M15 3h6v6" />
+                  <path d="M10 14 21 3" />
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
                 </svg>
                 <svg
                   v-else

--- a/src/components/database-browser/DataTableView.vue
+++ b/src/components/database-browser/DataTableView.vue
@@ -1314,7 +1314,7 @@ watch(
         </div>
 
         <!-- Scrollable form area -->
-        <div class="px-6 py-4 flex-1 overflow-y-auto space-y-3">
+        <div class="px-6 py-4 flex-1 min-h-0 overflow-y-auto space-y-3">
           <div
             v-for="col in (data?.columns ?? [])"
             :key="col"

--- a/src/components/grid/EditRowDialog.vue
+++ b/src/components/grid/EditRowDialog.vue
@@ -211,7 +211,7 @@ function handleClose(open: boolean) {
         </DialogTitle>
       </div>
 
-      <div class="px-6 py-4 flex-1 overflow-y-auto space-y-3">
+      <div class="px-6 py-4 flex-1 min-h-0 overflow-y-auto space-y-3">
         <div v-for="col in columns" :key="col" class="space-y-1">
           <div class="flex gap-2 items-center">
             <Label class="text-xs font-medium whitespace-nowrap">

--- a/src/components/sidebar/SchemaTree.vue
+++ b/src/components/sidebar/SchemaTree.vue
@@ -28,6 +28,7 @@ const emit = defineEmits<{
   (e: 'update:selectedSchema', schema: string): void
   (e: 'openListingTab', type: string, database: string, schema?: string): void
   (e: 'openDdlTab', name: string, type: string, database: string, schema?: string): void
+  (e: 'openQueryTab', database: string): void
 }>()
 
 const { t } = useI18n()
@@ -43,6 +44,7 @@ const loadingDatabases = ref<Set<string>>(new Set())
 
 // Context menu
 const contextMenuTable = ref<{ table: TableInfo, database: string, schema?: string, x: number, y: number } | null>(null)
+const contextMenuDatabase = ref<{ database: string, x: number, y: number } | null>(null)
 const selectedTreeItem = ref<{ type: string, name: string, schema?: string } | null>(null)
 
 const activeConnection = computed(() =>
@@ -150,7 +152,55 @@ function handleDoubleClick(table: TableInfo, schema: string | undefined) {
 
 function handleContextMenu(event: MouseEvent, table: TableInfo, schema: string | undefined) {
   event.preventDefault()
+  contextMenuDatabase.value = null
   contextMenuTable.value = { table, database: props.selectedDatabase!, schema, x: event.clientX, y: event.clientY }
+}
+
+function closeContextMenus() {
+  contextMenuTable.value = null
+  contextMenuDatabase.value = null
+}
+
+function handleDatabaseContextMenu(event: MouseEvent, dbName: string) {
+  event.preventDefault()
+  contextMenuTable.value = null
+  contextMenuDatabase.value = { database: dbName, x: event.clientX, y: event.clientY }
+}
+
+// Database-level context menu actions
+type DatabaseContextAction = 'openQuery' | 'showErDiagram' | 'refresh'
+
+function handleDatabaseContextAction(action: DatabaseContextAction) {
+  if (!contextMenuDatabase.value)
+    return
+  const { database } = contextMenuDatabase.value
+  const handlers: Record<DatabaseContextAction, () => void> = {
+    openQuery: () => emit('openQueryTab', database),
+    showErDiagram: () => emit('showErDiagram', database),
+    refresh: () => refreshDatabase(database),
+  }
+  handlers[action]()
+  contextMenuDatabase.value = null
+}
+
+async function refreshDatabase(dbName: string) {
+  if (!props.connectionId)
+    return
+  const connId = props.connectionId
+  loadingDatabases.value = new Set([...loadingDatabases.value, dbName])
+  try {
+    await databaseStore.fetchSchemas(connId, dbName)
+    const meta = databaseStore.metadata[connId]
+    const schemas = meta?.schemas[dbName] || []
+    const hasReal = schemas.some(s => s !== dbName)
+    if (hasReal)
+      await Promise.all(schemas.map(s => databaseStore.fetchTables(connId, dbName, s)))
+    else
+      await databaseStore.fetchTables(connId, dbName)
+  }
+  finally {
+    loadingDatabases.value = new Set([...loadingDatabases.value].filter(n => n !== dbName))
+  }
 }
 
 // Context menu action handler
@@ -330,7 +380,7 @@ defineExpose({ refresh })
 </script>
 
 <template>
-  <div class="flex flex-col h-full relative" @click="contextMenuTable = null">
+  <div class="flex flex-col h-full relative" @click="closeContextMenus">
     <!-- Initial loading overlay — only during first fetch, not during expand operations -->
     <div v-if="databaseStore.loading && allDatabases.length === 0" class="bg-background/60 flex items-center inset-0 justify-center absolute z-10">
       <div class="text-sm text-muted-foreground text-center">
@@ -509,6 +559,7 @@ defineExpose({ refresh })
         <button
           class="text-sm px-2 py-1 flex gap-1.5 w-full cursor-pointer items-center hover:bg-accent/40"
           @click="toggleDatabaseNode(db.name)"
+          @contextmenu="handleDatabaseContextMenu($event, db.name)"
         >
           <span class="i-lucide-chevron-right shrink-0 h-3 w-3 transition-transform" :class="{ 'rotate-90': expandedDatabases.has(db.name) }" />
           <span class="i-lucide-database text-yellow-500 shrink-0 h-3.5 w-3.5" />
@@ -648,6 +699,47 @@ defineExpose({ refresh })
       <p class="text-xs text-muted-foreground text-center">
         {{ t('sidebar.noDatabases') }}
       </p>
+    </div>
+
+    <!-- Click-away overlay: dismisses the context menu on any outside interaction -->
+    <div
+      v-if="contextMenuTable || contextMenuDatabase"
+      class="inset-0 fixed z-40"
+      @mousedown="closeContextMenus"
+      @contextmenu.prevent="closeContextMenus"
+    />
+
+    <!-- Database context menu -->
+    <div
+      v-if="contextMenuDatabase"
+      class="text-popover-foreground border rounded-md bg-popover w-48 shadow-md fixed z-50"
+      :style="{ left: `${contextMenuDatabase.x}px`, top: `${contextMenuDatabase.y}px` }"
+      @click.stop
+    >
+      <div class="p-1">
+        <div
+          class="text-sm px-2 py-1.5 rounded-sm flex cursor-pointer items-center hover:text-accent-foreground hover:bg-accent"
+          @click="handleDatabaseContextAction('openQuery')"
+        >
+          <span class="i-carbon-sql mr-2 h-3.5 w-3.5" />
+          {{ t('components.databaseBrowser.contextMenu.newQuery') }}
+        </div>
+        <div
+          class="text-sm px-2 py-1.5 rounded-sm flex cursor-pointer items-center hover:text-accent-foreground hover:bg-accent"
+          @click="handleDatabaseContextAction('showErDiagram')"
+        >
+          <span class="i-carbon-diagram mr-2 h-3.5 w-3.5" />
+          {{ t('components.databaseBrowser.contextMenu.showErDiagram') }}
+        </div>
+        <div class="my-1 bg-border h-px" />
+        <div
+          class="text-sm px-2 py-1.5 rounded-sm flex cursor-pointer items-center hover:text-accent-foreground hover:bg-accent"
+          @click="handleDatabaseContextAction('refresh')"
+        >
+          <span class="i-carbon-renew mr-2 h-3.5 w-3.5" />
+          {{ t('components.databaseBrowser.contextMenu.refresh') }}
+        </div>
+      </div>
     </div>
 
     <!-- Context Menu -->

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -1112,6 +1112,7 @@ export const enUS = {
     serverCard: {
       actions: {
         connect: 'Connect',
+        disconnect: 'Disconnect',
         edit: 'Edit',
         duplicate: 'Duplicate',
         delete: 'Delete',
@@ -1167,6 +1168,8 @@ export const enUS = {
         showErDiagram: 'Show ER Diagram',
         dropTable: 'Drop Table',
         truncateTable: 'Truncate',
+        newQuery: 'New Query',
+        refresh: 'Refresh',
       },
       savedQueryActions: {
         open: 'Open',

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -1112,7 +1112,7 @@ export const enUS = {
     serverCard: {
       actions: {
         connect: 'Connect',
-        disconnect: 'Disconnect',
+        closeConnection: 'Close Connection',
         edit: 'Edit',
         duplicate: 'Duplicate',
         delete: 'Delete',

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -1112,6 +1112,7 @@ export const enUS = {
     serverCard: {
       actions: {
         connect: 'Connect',
+        openEditor: 'Open in Editor',
         closeConnection: 'Close Connection',
         edit: 'Edit',
         duplicate: 'Duplicate',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -1111,6 +1111,7 @@ export const zhCN = {
     serverCard: {
       actions: {
         connect: '连接',
+        openEditor: '打开编辑器',
         closeConnection: '关闭连接',
         edit: '编辑',
         duplicate: '复制',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -1111,7 +1111,7 @@ export const zhCN = {
     serverCard: {
       actions: {
         connect: '连接',
-        disconnect: '断开连接',
+        closeConnection: '关闭连接',
         edit: '编辑',
         duplicate: '复制',
         delete: '删除',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -1111,6 +1111,7 @@ export const zhCN = {
     serverCard: {
       actions: {
         connect: '连接',
+        disconnect: '断开连接',
         edit: '编辑',
         duplicate: '复制',
         delete: '删除',
@@ -1166,6 +1167,8 @@ export const zhCN = {
         showErDiagram: '展示ER图表',
         dropTable: '删除表',
         truncateTable: '清空',
+        newQuery: '新建查询',
+        refresh: '刷新',
       },
       savedQueryActions: {
         open: '打开',

--- a/src/pages/ConnectionsPage.vue
+++ b/src/pages/ConnectionsPage.vue
@@ -133,12 +133,11 @@ async function handleConnect(connection: ServerConnection) {
   const status = connectionStore.getConnectionStatus(connection.id)
 
   if (status === ConnectionStatus.CONNECTED) {
-    try {
-      await connectionStore.disconnect(connection.id)
-    }
-    catch (error) {
-      connectError.value = error instanceof Error ? error.message : String(error)
-    }
+    // Already connected — primary action opens the connection in the editor.
+    router.push({
+      name: 'queries',
+      query: { connectionId: connection.id },
+    })
   }
   else {
     await establishConnection(connection, true)

--- a/src/pages/ConnectionsPage.vue
+++ b/src/pages/ConnectionsPage.vue
@@ -186,6 +186,18 @@ function handleDuplicateConnection(connection: ServerConnection) {
   isFormDialogOpen.value = true
 }
 
+async function handleDisconnect(connection: ServerConnection) {
+  connectError.value = null
+  if (!connection.id)
+    return
+  try {
+    await connectionStore.disconnect(connection.id)
+  }
+  catch (error) {
+    connectError.value = error instanceof Error ? error.message : String(error)
+  }
+}
+
 async function handleSaveConnection(connection: ServerConnection) {
   const result = await connectionStore.saveConnection(connection)
   if (!result.success) {
@@ -459,6 +471,7 @@ function getConnectionStatus(connectionId: string | undefined): ConnectionStatus
             @edit="handleEditConnection"
             @delete="handleDeleteConnection"
             @duplicate="handleDuplicateConnection"
+            @disconnect="handleDisconnect"
           />
 
           <!-- Add New Connection Card -->

--- a/src/pages/QueriesPage.vue
+++ b/src/pages/QueriesPage.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { StatementToExecute } from '@/composables/useSqlStatements'
-import type { DatabaseType } from '@/store/connectionStore'
 import type { TableInfo } from '@/store/databaseStore'
 import type { ApiResponse } from '@/types/api'
 import { invoke } from '@tauri-apps/api/core'
@@ -22,6 +21,7 @@ import { usePlatform } from '@/composables/usePlatform'
 import { useSqlFormatter } from '@/composables/useSqlFormatter'
 import { browseApi, loadQueryFile, saveQueryFile, saveQueryFileAs, saveQueryMetadata } from '@/datasources'
 import { ConnectionStatus, useAppStore, useConnectionStore, useDatabaseStore, useTabStore } from '@/store'
+import { DatabaseType } from '@/store/connectionStore'
 import { isApiSuccess } from '@/types/api'
 
 const { t } = useI18n()
@@ -313,6 +313,14 @@ function handleNewTab() {
   tabStore.createTab(connId ?? undefined, db)
 }
 
+function handleOpenQueryTab(database: string) {
+  const connId = getActiveConnectionId()
+  if (!connId)
+    return
+  const tab = tabStore.createTab(connId, database)
+  tabStore.setActiveTab(tab.id)
+}
+
 function handleTabSelect(tabId: string) {
   const tab = tabStore.tabById(tabId)
   if (tab?.orphanFromConnectionId) {
@@ -388,11 +396,48 @@ CREATE TABLE ${schemaPrefix}"${table.name}" (
   }
 }
 
-function handleSelectTopN(table: TableInfo, database: string, schema?: string, n = 100) {
-  const schemaPrefix = schema ? `"${schema}".` : ''
-  const query = `SELECT * FROM ${schemaPrefix}"${table.name}" LIMIT ${n};`
+// Databases speaking the MySQL dialect quote identifiers with backticks.
+const MYSQL_LIKE_DB_TYPES = new Set<DatabaseType>([
+  DatabaseType.MYSQL,
+  DatabaseType.MARIADB,
+  DatabaseType.TIDB,
+  DatabaseType.OCEANBASE,
+  DatabaseType.TDSQL,
+  DatabaseType.POLARDB,
+  DatabaseType.DORIS,
+  DatabaseType.SELECTDB,
+  DatabaseType.STARROCKS,
+  DatabaseType.DATABEND,
+  DatabaseType.GOLDENDB,
+  DatabaseType.MANTICORESEARCH,
+  DatabaseType.SINGLESTOREMEMSQL,
+  DatabaseType.CLOUDSQLMYSQL,
+])
 
+function quoteIdentifier(name: string, dbType: DatabaseType | undefined): string {
+  if (dbType === DatabaseType.SQLSERVER)
+    return `[${name.replace(/\]/g, ']]')}]`
+  if (dbType && MYSQL_LIKE_DB_TYPES.has(dbType))
+    return `\`${name.replace(/`/g, '``')}\``
+  return `"${name.replace(/"/g, '""')}"`
+}
+
+function buildSelectTopN(table: TableInfo, schema: string | undefined, n: number, dbType: DatabaseType | undefined): string {
+  const tableRef = schema
+    ? `${quoteIdentifier(schema, dbType)}.${quoteIdentifier(table.name, dbType)}`
+    : quoteIdentifier(table.name, dbType)
+  if (dbType === DatabaseType.SQLSERVER)
+    return `SELECT TOP ${n} * FROM ${tableRef};`
+  if (dbType === DatabaseType.ORACLE || dbType === DatabaseType.OCEANBASE_ORACLE)
+    return `SELECT * FROM ${tableRef} FETCH FIRST ${n} ROWS ONLY;`
+  return `SELECT * FROM ${tableRef} LIMIT ${n};`
+}
+
+function handleSelectTopN(table: TableInfo, database: string, schema?: string, n = 100) {
   const connId = getActiveConnectionId()
+  const dbType = connId ? connectionStore.getConnectionById(connId)?.type : undefined
+  const query = buildSelectTopN(table, schema, n, dbType)
+
   if (connId) {
     const tab = tabStore.createTab(connId, database, schema)
     tabStore.updateTabContent(tab.id, query)
@@ -975,6 +1020,7 @@ function closeResultPanel() {
                 @truncate-table="handleTruncateTable"
                 @open-listing-tab="handleOpenListingTab"
                 @open-ddl-tab="handleOpenDdlTab"
+                @open-query-tab="handleOpenQueryTab"
               />
             </template>
             <template #bottom>


### PR DESCRIPTION
## Summary

Fixes 6 issues reported against the treeview / connection management / data view UX.

### Backend — connection auto-reconnect (the big one)
When a connection session was lost (server restart, dropped connection) or idle-evicted, any user action failed with a hard `No active connection found for server 'xxx'` error because nothing ever recreated the connection handle. The agent/capabilities path already auto-reconnected; the main commands did not.

- `AppState` now stores the `ServerConfig` per active connection and exposes `ensure_connection()`, which transparently recreates the adapter (with SSH-tunnel resolution + connect timeout) when the handle is missing and notifies the guardian so the frontend flips back to CONNECTED.
- `connect_server` stores the config; `disconnect_server` removes it; the capabilities auto-connect path stores it too.
- Migrated **35 call sites** to `ensure_connection`: `browse.rs` (20), `query.rs` (5), `transfer.rs` (9), `mcp_bridge.rs`, `capabilities/commands.rs`, `cache.rs::get_or_create`, and the guardian's `try_reconnect` (which now *recreates* the adapter from config instead of pinging the stale one).
- If the server is genuinely down, the user now gets a clear `Reconnect timed out after N seconds` instead of the opaque error.

### Frontend
- **Executable top-N SQL**: "Query Top 100" emitted `SELECT * FROM "table" LIMIT 100` — double quotes are string literals in MySQL's default mode, so it was never executable. Now quotes identifiers per dialect (backticks for MySQL-family, `[brackets]` + `TOP n` for SQL Server, `FETCH FIRST` for Oracle) with delimiter escaping.
- **Database context menu**: right-clicking a database in the all-databases tree view now shows New Query / Show ER Diagram / Refresh (was only available for tables).
- **Menu dismissal**: tree context menus now close on any outside click or right-click via a click-away overlay.
- **Disconnect action**: connected connection cards in the home panel now show a Disconnect item in the action list.
- **Edit dialog scrolling**: `min-h-0` added to the form area of both edit dialogs so wide tables scroll inside `max-h-[80vh]` instead of overflowing the modal.

## Verification
- `cargo check` + `cargo clippy` clean (remaining warnings pre-existing)
- `cargo test`: 330 passed
- `vue-tsc --noEmit` clean
- `npm test`: 455 passed
- `npm run build` succeeds