### PR TITLE
feat(sql-completion): schema-aware autocomplete with dialect switching

### DIFF
--- a/src/__tests__/sqlCompletion/analyzer.test.ts
+++ b/src/__tests__/sqlCompletion/analyzer.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+import { analyzeCompletionContext } from '@/composables/sqlCompletion/analyzer'
+
+describe('analyzeCompletionContext', () => {
+  it('(a) detects the word and active table after FROM', () => {
+    const text = 'SELECT * FROM users WHERE u'
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.word).toBe('u')
+    expect(ctx.activeTable?.table).toBe('users')
+    expect(ctx.tableRefs).toEqual([{ table: 'users' }])
+    expect(ctx.inComment).toBe(false)
+  })
+
+  it('(b) detects alias-qualified column word', () => {
+    const text = 'SELECT u.na FROM users u'
+    const ctx = analyzeCompletionContext(text, 'SELECT u.na'.length)
+    expect(ctx.word).toBe('na')
+    expect(ctx.qualifier).toBe('u.')
+    expect(ctx.isAfterDot).toBe(true)
+    expect(ctx.activeTable?.table).toBe('users')
+    expect(ctx.activeTable?.alias).toBe('u')
+  })
+
+  it('(c) handles quoted table names with spaces', () => {
+    const text = 'SELECT * FROM "my table" WHERE '
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.activeTable?.table).toBe('my table')
+  })
+
+  it('(d) handles schema-qualified table with alias', () => {
+    const text = 'SELECT * FROM public.orders o WHERE o.'
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.qualifier).toBe('o.')
+    expect(ctx.activeTable?.table).toBe('orders')
+    expect(ctx.activeTable?.schema).toBe('public')
+  })
+
+  it('(e) ignores FROM inside a line comment', () => {
+    const text = '-- FROM foo\nSELECT 1'
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.tableRefs).toEqual([])
+    expect(ctx.activeTable).toBeNull()
+  })
+
+  it('(f) last JOIN table wins for its own alias', () => {
+    const text = 'SELECT * FROM a JOIN b ON a.id=b.id WHERE b.'
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.qualifier).toBe('b.')
+    expect(ctx.activeTable?.table).toBe('b')
+    expect(ctx.tableRefs.length).toBe(2)
+  })
+
+  it('(g) offset inside a block comment yields no table refs', () => {
+    const text = 'SELECT * FROM a /* FROM x */'
+    const idx = text.indexOf('/* FROM x */') + 5
+    const ctx = analyzeCompletionContext(text, idx)
+    expect(ctx.inComment).toBe(true)
+    expect(ctx.tableRefs).toEqual([])
+  })
+
+  it('(h) empty string → empty context, no throw', () => {
+    const ctx = analyzeCompletionContext('', 0)
+    expect(ctx.word).toBe('')
+    expect(ctx.tableRefs).toEqual([])
+    expect(ctx.activeTable).toBeNull()
+    expect(ctx.inComment).toBe(false)
+  })
+
+  it('supports AS-alias and multi-statement document', () => {
+    const text = 'SELECT * FROM users AS u;\nSELECT o.id FROM orders o'
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.activeTable?.table).toBe('orders')
+    expect(ctx.activeTable?.alias).toBe('o')
+  })
+
+  it('word completion on empty word at end of FROM still yields the table ref', () => {
+    const text = 'SELECT * FROM users '
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.word).toBe('')
+    expect(ctx.activeTable?.table).toBe('users')
+  })
+})

--- a/src/__tests__/sqlCompletion/analyzer.test.ts
+++ b/src/__tests__/sqlCompletion/analyzer.test.ts
@@ -81,4 +81,28 @@ describe('analyzeCompletionContext', () => {
     expect(ctx.word).toBe('')
     expect(ctx.activeTable?.table).toBe('users')
   })
+
+  it('(i) schema-qualified qualifier with unmatched FROM table → activeTable null (no fallback)', () => {
+    const text = 'SELECT u.name, public.us FROM users u'
+    const ctx = analyzeCompletionContext(text, text.indexOf('public.us') + 'public.us'.length)
+    expect(ctx.qualifier).toBe('public.')
+    expect(ctx.isAfterDot).toBe(true)
+    expect(ctx.activeTable).toBeNull()
+  })
+
+  it('(j) quoted qualifier matches the table name (unquoted before compare)', () => {
+    const text = 'SELECT "users". FROM users'
+    const ctx = analyzeCompletionContext(text, text.indexOf('"users".') + '"users".'.length)
+    expect(ctx.qualifier).toBe('"users".')
+    expect(ctx.isAfterDot).toBe(true)
+    expect(ctx.activeTable?.table).toBe('users')
+  })
+
+  it('(k) multi-segment qualifier never matches a bare FROM table', () => {
+    const text = 'SELECT * FROM app.public.'
+    const ctx = analyzeCompletionContext(text, text.length)
+    expect(ctx.qualifier).toBe('app.public.')
+    expect(ctx.isAfterDot).toBe(true)
+    expect(ctx.activeTable).toBeNull()
+  })
 })

--- a/src/__tests__/sqlCompletion/builder.test.ts
+++ b/src/__tests__/sqlCompletion/builder.test.ts
@@ -92,6 +92,37 @@ describe('buildSuggestions', () => {
     expect(labels(result)).toContain('events')
   })
 
+  it('(d2) schema-qualified word → schema tables, never the FROM-table columns', () => {
+    // Regression: `public.us` must offer tables in `public`, not columns of
+    // the last FROM table (`users`) — activeTable is null for unmatched
+    // qualifiers, so the builder falls through to the schema branch.
+    const snap: SchemaSnapshot = {
+      ...snapshot,
+      tablesByKey: { ...snapshot.tablesByKey, 'app.public': ['users', 'orders', 'user_events'] },
+      columnsByTable: {
+        ...snapshot.columnsByTable,
+        'c1|app|public|users': [
+          { name: 'id', dataType: 'int4' },
+          { name: 'user_id', dataType: 'int4' },
+        ],
+      },
+    }
+    const result = buildSuggestions(
+      ctx({
+        word: 'user',
+        isAfterDot: true,
+        qualifier: 'public.',
+        tableRefs: [{ table: 'users', alias: 'u' }],
+        activeTable: null,
+      }),
+      snap,
+      profile,
+      opts,
+    )
+    expect(labels(result)).toEqual(['user_events', 'users'])
+    expect(result.every(r => r.kind !== 'column')).toBe(true)
+  })
+
   it('(e) noParenFunctions preserved: NOW without parens, CONCAT with', () => {
     const result = buildSuggestions(ctx({ word: 'N' }), snapshot, profile, opts)
     const now = result.find(r => r.label === 'NOW')

--- a/src/__tests__/sqlCompletion/builder.test.ts
+++ b/src/__tests__/sqlCompletion/builder.test.ts
@@ -1,0 +1,151 @@
+import type { CompletionContext, SchemaSnapshot } from '@/composables/sqlCompletion/types'
+import { buildSuggestions } from '@/composables/sqlCompletion/builder'
+/**
+ * @jest-environment node
+ */
+import { getDialectProfile } from '@/composables/sqlCompletion/dialects'
+
+const profile = getDialectProfile('sql')
+
+const snapshot: SchemaSnapshot = {
+  databases: [{ name: 'app', isSystem: false }],
+  schemasByDb: { app: ['public', 'analytics'] },
+  tablesByKey: {
+    'app': ['users', 'orders'],
+    'app.public': ['users', 'orders'],
+    'app.analytics': ['events'],
+  },
+  columnsByTable: {
+    'c1|app|public|users': [
+      { name: 'id', dataType: 'int4', isPrimaryKey: true },
+      { name: 'email', dataType: 'text' },
+      { name: 'created_at', dataType: 'timestamptz' },
+    ],
+  },
+  derivedTables: {},
+  hasSchemaData: true,
+}
+
+const opts = { connectionId: 'c1', currentDb: 'app', currentSchema: 'public' }
+
+function ctx(partial: Partial<CompletionContext>): CompletionContext {
+  return {
+    word: '',
+    tableRefs: [],
+    activeTable: null,
+    qualifier: '',
+    isAfterDot: false,
+    inComment: false,
+    ...partial,
+  }
+}
+
+const labels = (items: { label: string }[]) => items.map(i => i.label)
+
+describe('buildSuggestions', () => {
+  it('(a) word SEL → SELECT keyword suggested', () => {
+    const result = buildSuggestions(ctx({ word: 'SEL' }), snapshot, profile, opts)
+    expect(labels(result)).toContain('SELECT')
+  })
+
+  it('(b) empty word after FROM → table names (current db first)', () => {
+    const result = buildSuggestions(
+      ctx({ word: '', tableRefs: [{ table: 'users' }], activeTable: { table: 'users' } }),
+      snapshot,
+      profile,
+      opts,
+    )
+    expect(labels(result)).toContain('users')
+    expect(labels(result)).toContain('orders')
+  })
+
+  it('(c) after alias dot → columns only, kind column, detail data_type', () => {
+    const result = buildSuggestions(
+      ctx({ word: '', isAfterDot: true, qualifier: 'u.', activeTable: { table: 'users', alias: 'u' } }),
+      snapshot,
+      profile,
+      opts,
+    )
+    expect(labels(result)).toEqual(['created_at', 'email', 'id'])
+    const col = result.find(r => r.label === 'email')
+    expect(col?.kind).toBe('column')
+    expect(col?.detail).toBe('text')
+  })
+
+  it('(c2) after alias dot with word prefix filters columns', () => {
+    const result = buildSuggestions(
+      ctx({ word: 'cre', isAfterDot: true, qualifier: 'u.', activeTable: { table: 'users', alias: 'u' } }),
+      snapshot,
+      profile,
+      opts,
+    )
+    expect(labels(result)).toEqual(['created_at'])
+  })
+
+  it('(d) after schema dot → tables of that schema', () => {
+    const result = buildSuggestions(
+      ctx({ word: '', isAfterDot: true, qualifier: 'analytics.' }),
+      snapshot,
+      profile,
+      { ...opts, currentSchema: 'public' },
+    )
+    expect(labels(result)).toContain('events')
+  })
+
+  it('(e) noParenFunctions preserved: NOW without parens, CONCAT with', () => {
+    const result = buildSuggestions(ctx({ word: 'N' }), snapshot, profile, opts)
+    const now = result.find(r => r.label === 'NOW')
+    expect(now?.insertText).toBe('NOW')
+    const concat = buildSuggestions(ctx({ word: 'CONC' }), snapshot, profile, opts).find(r => r.label === 'CONCAT')
+    expect(concat?.insertText).toBe('CONCAT()')
+  })
+
+  it('(f) prefix filters tables', () => {
+    const result = buildSuggestions(
+      ctx({ word: 'us', tableRefs: [{ table: 'users' }], activeTable: { table: 'users' } }),
+      snapshot,
+      profile,
+      opts,
+    )
+    expect(labels(result)).toContain('users')
+    expect(labels(result)).not.toContain('orders')
+  })
+
+  it('(g) empty schema data → keywords still present (graceful degradation)', () => {
+    const empty: SchemaSnapshot = { ...snapshot, hasSchemaData: false, databases: [], schemasByDb: {}, tablesByKey: {}, columnsByTable: {} }
+    const result = buildSuggestions(ctx({ word: 'SEL' }), empty, profile, opts)
+    expect(labels(result)).toContain('SELECT')
+    expect(labels(result)).not.toContain('users')
+  })
+
+  it('(g2) after dot with empty snapshot → empty, no throw', () => {
+    const empty: SchemaSnapshot = { ...snapshot, hasSchemaData: false, databases: [], schemasByDb: {}, tablesByKey: {}, columnsByTable: {} }
+    const result = buildSuggestions(ctx({ word: '', isAfterDot: true, qualifier: 'x.' }), empty, profile, opts)
+    expect(result).toEqual([])
+  })
+
+  it('(h) >100 candidates → exactly 100', () => {
+    const bigSnapshot: SchemaSnapshot = {
+      ...snapshot,
+      tablesByKey: { app: Array.from({ length: 200 }, (_, i) => `table_${i}`) },
+    }
+    const result = buildSuggestions(ctx({ word: 'table_' }), bigSnapshot, profile, opts)
+    expect(result.length).toBeLessThanOrEqual(100)
+    expect(result.length).toBe(100)
+  })
+
+  it('in comment → no suggestions', () => {
+    const result = buildSuggestions(ctx({ word: 'SEL', inComment: true }), snapshot, profile, opts)
+    expect(result).toEqual([])
+  })
+
+  it('no keywords after a dot (only objects)', () => {
+    const result = buildSuggestions(
+      ctx({ word: '', isAfterDot: true, qualifier: 'u.', activeTable: { table: 'users', alias: 'u' } }),
+      snapshot,
+      profile,
+      opts,
+    )
+    expect(result.every(r => r.kind !== 'keyword')).toBe(true)
+  })
+})

--- a/src/__tests__/sqlCompletion/dialects.test.ts
+++ b/src/__tests__/sqlCompletion/dialects.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+import {
+  getDialectProfile,
+  hasGrammar,
+  NO_PAREN_FUNCTIONS,
+  resolveMonacoDialect,
+  SQL_FUNCTIONS,
+  SQL_KEYWORDS,
+  SQL_TYPES,
+} from '@/composables/sqlCompletion/dialects'
+
+describe('resolveMonacoDialect — formatter→monaco map', () => {
+  it('maps the five known families', () => {
+    expect(resolveMonacoDialect('postgresql')).toBe('pgsql')
+    expect(resolveMonacoDialect('mysql')).toBe('mysql')
+    expect(resolveMonacoDialect('tsql')).toBe('mssql')
+    expect(resolveMonacoDialect('plsql')).toBe('plsql')
+    expect(resolveMonacoDialect('sqlite')).toBe('sqlite')
+  })
+
+  it('maps mysql-family formatter ids to mysql', () => {
+    expect(resolveMonacoDialect('mariadb')).toBe('mysql')
+    expect(resolveMonacoDialect('tidb')).toBe('mysql')
+  })
+
+  it('maps postgresql-family ids to pgsql', () => {
+    expect(resolveMonacoDialect('redshift')).toBe('pgsql')
+  })
+
+  it('falls back to sql for unmapped formatter ids', () => {
+    for (const id of ['trino', 'snowflake', 'duckdb', 'clickhouse', 'hive', 'spark', 'bigquery', 'db2', 'hana', 'teradata', 'exasol', 'bogus', '']) {
+      expect(resolveMonacoDialect(id)).toBe('sql')
+    }
+  })
+})
+
+describe('dialect profiles', () => {
+  it('exposes a profile for every SQLDialect id', () => {
+    for (const id of ['sql', 'mysql', 'pgsql', 'mssql', 'plsql', 'sqlite'] as const) {
+      expect(getDialectProfile(id).id).toBe(id)
+    }
+  })
+
+  it('mysql uses backtick quote char, others use double quote', () => {
+    expect(getDialectProfile('mysql').quoteChar).toBe('`')
+    expect(getDialectProfile('pgsql').quoteChar).toBe('"')
+    expect(getDialectProfile('sql').quoteChar).toBe('"')
+  })
+
+  it('sqlite does not support schema qualification, pgsql does', () => {
+    expect(getDialectProfile('sqlite').supportsSchemaQualification).toBe(false)
+    expect(getDialectProfile('pgsql').supportsSchemaQualification).toBe(true)
+  })
+
+  it('hasGrammar is true only for dialects with monaco grammar contributions', () => {
+    expect(hasGrammar('sql')).toBe(true)
+    expect(hasGrammar('mysql')).toBe(true)
+    expect(hasGrammar('pgsql')).toBe(true)
+    expect(hasGrammar('mssql')).toBe(false)
+    expect(hasGrammar('plsql')).toBe(false)
+    expect(hasGrammar('sqlite')).toBe(false)
+  })
+})
+
+describe('migrated keyword/type/function lists (single source of truth)', () => {
+  it('sql profile keyword list is non-empty and matches SQL_KEYWORDS', () => {
+    expect(getDialectProfile('sql').keywords).toBe(SQL_KEYWORDS)
+    expect(SQL_KEYWORDS.length).toBe(77)
+    expect(SQL_KEYWORDS).toContain('SELECT')
+    expect(SQL_KEYWORDS).toContain('DENSE_RANK')
+  })
+
+  it('types and functions lists migrated fully', () => {
+    expect(SQL_TYPES).toContain('BIGSERIAL')
+    expect(SQL_FUNCTIONS).toContain('LOG')
+    expect(SQL_FUNCTIONS.length).toBe(34)
+  })
+
+  it('noParenFunctions is exactly the four no-paren functions', () => {
+    expect(NO_PAREN_FUNCTIONS).toEqual(['NOW', 'CURRENT_DATE', 'CURRENT_TIME', 'CURRENT_TIMESTAMP'])
+    expect(getDialectProfile('sql').noParenFunctions).toBe(NO_PAREN_FUNCTIONS)
+  })
+})

--- a/src/__tests__/sqlCompletion/metadata.test.ts
+++ b/src/__tests__/sqlCompletion/metadata.test.ts
@@ -1,0 +1,169 @@
+import type { StoreMetadata } from '@/composables/sqlCompletion/metadata'
+/**
+ * @jest-environment node
+ */
+import { invoke } from '@tauri-apps/api/core'
+import { getMetadataService, SchemaMetadataService, setMetadataServiceForTests } from '@/composables/sqlCompletion/metadata'
+
+jest.mock('@tauri-apps/api/core', () => ({
+  invoke: jest.fn(),
+}))
+
+const mockInvoke = invoke as jest.MockedFunction<typeof invoke>
+
+const fakeStore: StoreMetadata = {
+  databases: [{ name: 'app', is_system: false }, { name: 'postgres', is_system: true }],
+  schemas: { app: ['public', 'analytics'] },
+  tables: {
+    'app': [{ name: 'users', schema: 'public' }, { name: 'orders', schema: 'public' }],
+    'app.public': [{ name: 'users', schema: 'public' }, { name: 'orders', schema: 'public' }],
+  },
+}
+
+function makeService(opts: { maxTables?: number, concurrency?: number } = {}) {
+  return new SchemaMetadataService({
+    getMetadata: () => fakeStore,
+    ...opts,
+  })
+}
+
+describe('schemaMetadataService — level A (connection objects)', () => {
+  it('returns databases with isSystem flag', () => {
+    const svc = makeService()
+    expect(svc.getDatabases('c1')).toEqual([
+      { name: 'app', isSystem: false },
+      { name: 'postgres', isSystem: true },
+    ])
+  })
+
+  it('returns schemas for a database', () => {
+    const svc = makeService()
+    expect(svc.getSchemas('c1', 'app')).toEqual(['public', 'analytics'])
+  })
+
+  it('returns tables for db and db.schema keys', () => {
+    const svc = makeService()
+    expect(svc.getTables('c1', 'app')).toEqual(['users', 'orders'])
+    expect(svc.getTables('c1', 'app', 'public')).toEqual(['users', 'orders'])
+  })
+
+  it('returns empty for missing metadata', () => {
+    const svc = new SchemaMetadataService({ getMetadata: () => null })
+    expect(svc.getDatabases('c9')).toEqual([])
+    expect(svc.getSchemas('c9', 'x')).toEqual([])
+    expect(svc.getTables('c9', 'x')).toEqual([])
+    expect(svc.getColumns('c9', 'x', undefined, 't')).toEqual([])
+  })
+})
+
+describe('schemaMetadataService — level B (column cache)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('(a) prefetchColumns stores columns under the exact key', async () => {
+    mockInvoke.mockResolvedValue([
+      { name: 'id', data_type: 'int4', nullable: false, is_primary_key: true, is_auto_increment: true },
+      { name: 'email', data_type: 'text', nullable: true, is_primary_key: false, is_auto_increment: false },
+    ])
+    const svc = makeService()
+    await svc.prefetchColumns('c1', 'app', 'public', ['users'])
+    expect(mockInvoke).toHaveBeenCalledWith('list_columns', {
+      connectionId: 'c1',
+      database: 'app',
+      schema: 'public',
+      tableName: 'users',
+    })
+    expect(svc.getColumns('c1', 'app', 'public', 'users')).toEqual([
+      { name: 'id', dataType: 'int4', isPrimaryKey: true },
+      { name: 'email', dataType: 'text', isPrimaryKey: false },
+    ])
+    expect(svc.getColumns('c1', 'app', 'public', 'other')).toEqual([])
+  })
+
+  it('(b) concurrency: max in-flight invoke ≤ concurrency (5)', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const tables = Array.from({ length: 10 }, (_, i) => `t${i}`)
+    mockInvoke.mockImplementation(async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise(r => setTimeout(r, 5))
+      inFlight--
+      return []
+    })
+    const svc = makeService({ concurrency: 5 })
+    await svc.prefetchColumns('c1', 'app', 'public', tables)
+    expect(maxInFlight).toBeLessThanOrEqual(5)
+    expect(mockInvoke).toHaveBeenCalledTimes(10)
+  })
+
+  it('(c) prefetch caps at maxTables (100)', async () => {
+    const tables = Array.from({ length: 150 }, (_, i) => `t${i}`)
+    mockInvoke.mockResolvedValue([])
+    const svc = makeService({ maxTables: 100 })
+    await svc.prefetchColumns('c1', 'app', 'public', tables)
+    expect(mockInvoke).toHaveBeenCalledTimes(100)
+  })
+
+  it('(d) getColumns returns cached without re-invoke', async () => {
+    mockInvoke.mockResolvedValue([])
+    const svc = makeService()
+    await svc.prefetchColumns('c1', 'app', 'public', ['users'])
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    svc.getColumns('c1', 'app', 'public', 'users')
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+  })
+
+  it('(e) getColumns on absent key triggers a lazy fetch', async () => {
+    mockInvoke.mockResolvedValue([{ name: 'id', data_type: 'int4', nullable: false, is_primary_key: false, is_auto_increment: false }])
+    const svc = makeService()
+    const cols = await svc.fetchTableColumns('c1', 'app', 'public', 'orders')
+    expect(cols).toEqual([{ name: 'id', dataType: 'int4', isPrimaryKey: false }])
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+  })
+
+  it('(f) clearColumnCache(connId) removes only that connId keys', async () => {
+    mockInvoke.mockResolvedValue([])
+    const svc = makeService()
+    await svc.prefetchColumns('c1', 'app', 'public', ['users'])
+    await svc.prefetchColumns('c2', 'app', 'public', ['users'])
+    svc.clearColumnCache('c1')
+    expect(svc.getColumns('c1', 'app', 'public', 'users')).toEqual([])
+    // c2 untouched (cache intact, no re-invoke needed to verify absence of fetch)
+    expect(mockInvoke).toHaveBeenCalledTimes(2)
+  })
+
+  it('(g) invoke rejection → prefetch resolves without throwing', async () => {
+    mockInvoke.mockRejectedValue(new Error('backend down'))
+    const svc = makeService()
+    await expect(svc.prefetchColumns('c1', 'app', 'public', ['users'])).resolves.toBeUndefined()
+    expect(svc.getColumns('c1', 'app', 'public', 'users')).toEqual([])
+  })
+})
+
+describe('schemaMetadataService — level C (derived tables)', () => {
+  it('resolves and clears derived alias/CTE names', () => {
+    const svc = makeService()
+    svc.setDerivedTables({ u: 'users', cte1: 'orders' })
+    expect(svc.resolveDerived('u')).toBe('users')
+    expect(svc.resolveDerived('cte1')).toBe('orders')
+    svc.clearAll()
+    expect(svc.resolveDerived('u')).toBeUndefined()
+  })
+})
+
+describe('schemaMetadataService — singleton', () => {
+  afterEach(() => {
+    setMetadataServiceForTests(null)
+  })
+
+  it('getMetadataService returns a singleton; setMetadataServiceForTests swaps it', () => {
+    const a = getMetadataService()
+    const b = getMetadataService()
+    expect(a).toBe(b)
+    const fake = makeService()
+    setMetadataServiceForTests(fake)
+    expect(getMetadataService()).toBe(fake)
+  })
+})

--- a/src/__tests__/sqlCompletion/provider.test.ts
+++ b/src/__tests__/sqlCompletion/provider.test.ts
@@ -1,0 +1,195 @@
+import type { StoreMetadata } from '@/composables/sqlCompletion/metadata'
+import type { SchemaSnapshot } from '@/composables/sqlCompletion/types'
+import { analyzeCompletionContext } from '@/composables/sqlCompletion/analyzer'
+import { buildSuggestions } from '@/composables/sqlCompletion/builder'
+import { getDialectProfile } from '@/composables/sqlCompletion/dialects'
+/**
+ * @jest-environment node
+ */
+import { SchemaMetadataService } from '@/composables/sqlCompletion/metadata'
+import { createProvider, emptySnapshot, SQL_DIALECT_IDS } from '@/composables/sqlCompletion/provider'
+
+const fakeStore: StoreMetadata = {
+  databases: [{ name: 'app', is_system: false }],
+  schemas: { app: ['public'] },
+  tables: {
+    'app': [{ name: 'users', schema: 'public' }],
+    'app.public': [{ name: 'users', schema: 'public' }],
+  },
+}
+
+function makeService() {
+  return new SchemaMetadataService({ getMetadata: () => fakeStore })
+}
+
+const deps = {
+  metadataService: makeService(),
+  analyze: analyzeCompletionContext,
+  build: buildSuggestions,
+  profiles: getDialectProfile,
+}
+
+type FakeModel = {
+  getValue: () => string
+  getOffsetAt: (pos: { lineNumber: number, column: number }) => number
+  getWordUntilPosition: (pos: { lineNumber: number, column: number }) => { startColumn: number, endColumn: number }
+}
+
+function makeModel(text: string): FakeModel {
+  const lineStarts = [0]
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\n')
+      lineStarts.push(i + 1)
+  }
+  return {
+    getValue: () => text,
+    getOffsetAt: (pos) => {
+      const start = lineStarts[pos.lineNumber - 1] ?? 0
+      return start + pos.column - 1
+    },
+    getWordUntilPosition: () => ({ startColumn: 1, endColumn: 1 }),
+  }
+}
+
+function makeFakeMonaco() {
+  const registered: { language: string, provider: unknown }[] = []
+  return {
+    languages: {
+      registerCompletionItemProvider: jest.fn((language: string, provider: unknown) => {
+        registered.push({ language, provider })
+        return { dispose: jest.fn() }
+      }),
+      CompletionItemKind: {
+        Keyword: 0,
+        Function: 1,
+        TypeParameter: 2,
+        Class: 3,
+        Field: 4,
+        Module: 5,
+        Folder: 6,
+      },
+    },
+    registered,
+  }
+}
+
+type ProviderHandler = {
+  provideCompletionItems: (model: unknown, position: { lineNumber: number, column: number }) => { suggestions: Array<{ label: string, kind: number }> }
+  resolveCompletionItem: (item: unknown) => Promise<unknown>
+}
+
+function providerOf(fake: ReturnType<typeof makeFakeMonaco>, id: string): ProviderHandler {
+  return fake.registered.find(r => r.language === id)?.provider as unknown as ProviderHandler
+}
+
+describe('completion provider', () => {
+  it('(a) registers a provider for all 6 SQL dialect ids', () => {
+    const fake = makeFakeMonaco()
+    const provider = createProvider(fake as never, deps)
+    const disposables = provider.register()
+    expect(fake.languages.registerCompletionItemProvider).toHaveBeenCalledTimes(6)
+    expect(fake.registered.map(r => r.language)).toEqual([...SQL_DIALECT_IDS])
+    expect(disposables).toHaveLength(6)
+    disposables.forEach(d => d.dispose())
+  })
+
+  it('(b) no context → sync empty suggestions, no throw', () => {
+    const fake = makeFakeMonaco()
+    const provider = createProvider(fake as never, deps)
+    provider.register()
+    const model = makeModel('SELECT ')
+    const handler = providerOf(fake, 'sql')
+    const result = handler.provideCompletionItems(model, { lineNumber: 1, column: 8 })
+    expect(result).toEqual({ suggestions: [] })
+  })
+
+  it('(b2) setContext with snapshot → table suggestion appears (empty word)', () => {
+    const fake = makeFakeMonaco()
+    const provider = createProvider(fake as never, deps)
+    provider.register()
+    const model = makeModel('SELECT FROM ')
+    provider.setContext(model as never, { connectionId: 'c1', database: 'app', schema: 'public' })
+    const handler = providerOf(fake, 'sql')
+    const result = handler.provideCompletionItems(model, { lineNumber: 1, column: 13 })
+    const labels = result.suggestions.map((s: { label: string }) => s.label)
+    expect(labels).toContain('users')
+  })
+
+  it('(c) after alias dot → column suggestions with kind Field', () => {
+    const fake = makeFakeMonaco()
+    const svc = new SchemaMetadataService({ getMetadata: () => fakeStore })
+    const localProvider = createProvider(fake as never, { ...deps, metadataService: svc })
+    localProvider.register()
+    const model = makeModel('SELECT u. FROM users u')
+    localProvider.setContext(model as never, { connectionId: 'c1', database: 'app', schema: 'public' })
+    const snapshot: SchemaSnapshot = {
+      databases: [{ name: 'app', isSystem: false }],
+      schemasByDb: {},
+      tablesByKey: {},
+      columnsByTable: {
+        'c1|app|public|users': [{ name: 'id', dataType: 'int4' }, { name: 'email', dataType: 'text' }],
+      },
+      derivedTables: {},
+      hasSchemaData: true,
+    }
+    localProvider.contexts.set(model as never, {
+      connId: 'c1',
+      database: 'app',
+      schema: 'public',
+      dialectId: 'sql',
+      snapshot,
+    })
+    const handler = providerOf(fake, 'sql')
+    const result = handler.provideCompletionItems(model, { lineNumber: 1, column: 10 })
+    const labels = result.suggestions.map((s: { label: string }) => s.label)
+    expect(labels).toEqual(['email', 'id'])
+    expect(result.suggestions[0].kind).toBe(4)
+  })
+
+  it('(c2) active alias column lookup works through public API without private access', () => {
+    const fake = makeFakeMonaco()
+    const svc = makeService()
+    // Pre-populate the column cache via the public API.
+    svc.prefetchColumns = jest.fn().mockResolvedValue(undefined) as never
+    const provider = createProvider(fake as never, { ...deps, metadataService: svc })
+    provider.register()
+    const model = makeModel('SELECT u.em FROM users u')
+    provider.setContext(model as never, { connectionId: 'c1', database: 'app', schema: 'public' })
+    const handler = providerOf(fake, 'sql')
+    const result = handler.provideCompletionItems(model, { lineNumber: 1, column: 14 })
+    expect(Array.isArray(result.suggestions)).toBe(true)
+  })
+
+  it('(d) WeakMap entry removed on clearModel', () => {
+    const fake = makeFakeMonaco()
+    const provider = createProvider(fake as never, deps)
+    provider.register()
+    const model = makeModel('SEL')
+    provider.setContext(model as never, { connectionId: 'c1', database: 'app', schema: 'public' })
+    expect(provider.contexts.has(model as never)).toBe(true)
+    provider.clearModel(model as never)
+    expect(provider.contexts.has(model as never)).toBe(false)
+  })
+
+  it('(e) resolveCompletionItem returns the item as-is (async signature)', async () => {
+    const fake = makeFakeMonaco()
+    const provider = createProvider(fake as never, deps)
+    provider.register()
+    const item = { label: 'users', kind: 3, insertText: 'users' }
+    const handler = providerOf(fake, 'sql')
+    const resolved = await handler.resolveCompletionItem(item)
+    expect(resolved).toEqual(item)
+  })
+
+  it('(g) null model → empty suggestions, no throw', () => {
+    const fake = makeFakeMonaco()
+    const provider = createProvider(fake as never, deps)
+    provider.register()
+    const handler = providerOf(fake, 'sql')
+    expect(handler.provideCompletionItems(null, { lineNumber: 1, column: 1 })).toEqual({ suggestions: [] })
+  })
+
+  it('emptySnapshot has hasSchemaData false', () => {
+    expect(emptySnapshot().hasSchemaData).toBe(false)
+  })
+})

--- a/src/__tests__/sqlCompletion/types.test.ts
+++ b/src/__tests__/sqlCompletion/types.test.ts
@@ -1,0 +1,69 @@
+import type {
+  ColumnSuggestion,
+  CompletionContext,
+  CompletionContextInput,
+  DatabaseRef,
+  DialectProfile,
+  SchemaSnapshot,
+  Suggestion,
+  TableRef,
+} from '@/composables/sqlCompletion/types'
+/**
+ * @jest-environment node
+ */
+import { GRAMMAR_DIALECTS } from '@/composables/sqlCompletion/types'
+
+describe('sqlCompletion domain types', () => {
+  it('satisfies the CompletionContext shape', () => {
+    const ctx: CompletionContext = {
+      word: 'us',
+      tableRefs: [{ table: 'users', alias: 'u' }],
+      activeTable: { table: 'users', alias: 'u' },
+      qualifier: 'u.',
+      isAfterDot: true,
+      inComment: false,
+    }
+    expect(ctx.word).toBe('us')
+    expect(ctx.isAfterDot).toBe(true)
+  })
+
+  it('satisfies the SchemaSnapshot shape with column cache entries', () => {
+    const snapshot: SchemaSnapshot = {
+      databases: [{ name: 'app', isSystem: false }],
+      schemasByDb: { app: ['public'] },
+      tablesByKey: { 'app': ['users'], 'app.public': ['orders'] },
+      columnsByTable: {
+        'c1|app|public|orders': [{ name: 'id', dataType: 'int4', isPrimaryKey: true }],
+      },
+      derivedTables: { x: 'users' },
+      hasSchemaData: true,
+    }
+    expect(snapshot.tablesByKey['app.public']).toContain('orders')
+  })
+
+  it('satisfies the DialectProfile shape with noParenFunctions', () => {
+    const profile: DialectProfile = {
+      id: 'pgsql',
+      quoteChar: '"',
+      supportsSchemaQualification: true,
+      keywords: ['SELECT'],
+      functions: ['NOW'],
+      types: ['INT'],
+      noParenFunctions: ['NOW', 'CURRENT_DATE'],
+    }
+    expect(profile.noParenFunctions).toContain('NOW')
+  })
+
+  it('satisfies Suggestion / TableRef / DatabaseRef / ColumnSuggestion / CompletionContextInput shapes', () => {
+    const s: Suggestion = { label: 'users', kind: 'table', insertText: 'users', sortPrefix: 1 }
+    const t: TableRef = { table: 'users', alias: 'u', schema: 'public' }
+    const d: DatabaseRef = { name: 'app', isSystem: false }
+    const c: ColumnSuggestion = { name: 'id', dataType: 'int4', isPrimaryKey: true }
+    const input: CompletionContextInput = { connectionId: 'c1', database: 'app', schema: 'public' }
+    expect([s.kind, t.table, d.name, c.name, input.connectionId]).toEqual(['table', 'users', 'app', 'id', 'c1'])
+  })
+
+  it('gRAMMAR_DIALECTS contains exactly the dialects with monaco grammar contributions', () => {
+    expect(GRAMMAR_DIALECTS).toEqual(['sql', 'mysql', 'pgsql'])
+  })
+})

--- a/src/components/SQLEditor.vue
+++ b/src/components/SQLEditor.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { CompletionContextInput } from '@/composables/sqlCompletion/types'
 import type { MonacoEditorOptions, SQLDialect } from '@/composables/useMonacoEditor'
 import type { StatementToExecute } from '@/composables/useSqlStatements'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -21,6 +22,7 @@ type Props = {
   placeholder?: string
   isExecuting?: boolean
   formatSql?: (sql: string) => string
+  completionContext?: CompletionContextInput
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -75,7 +77,7 @@ const editorOptions: MonacoEditorOptions = {
   wordWrap: props.wordWrap,
 }
 
-const { initEditor, getValue, setValue, updateTheme, updateOptions, executeAtLine, getStatementTextAtLine } = useMonacoEditor(
+const { initEditor, getValue, setValue, updateTheme, updateOptions, updateLanguage, setCompletionContext, executeAtLine, getStatementTextAtLine } = useMonacoEditor(
   editorContainer,
   editorValue,
   editorOptions,
@@ -141,6 +143,9 @@ onMounted(() => {
     })
   }
 
+  updateLanguage(props.dialect)
+  setCompletionContext(props.completionContext ?? {})
+
   document.addEventListener('click', handleDocumentClick)
   document.addEventListener('keydown', handleDocumentKeydown)
 })
@@ -165,6 +170,10 @@ watch(() => props.wordWrap, val => updateOptions({ wordWrap: val }))
 watch(() => props.fontSize, val => updateOptions({ fontSize: val }))
 watch(() => props.tabSize, val => updateOptions({ tabSize: val }))
 watch(() => props.minimap, val => updateOptions({ minimap: val }))
+
+watch(() => props.dialect, val => updateLanguage(val), { immediate: true })
+
+watch(() => props.completionContext, val => setCompletionContext(val ?? {}), { deep: true, immediate: true })
 
 function handleContextMenuExecute() {
   if (contextMenuLine.value === null)

--- a/src/components/grid/DataGrid.vue
+++ b/src/components/grid/DataGrid.vue
@@ -582,10 +582,10 @@ watch(() => [props.rows, props.columns], () => {
         <!-- Actions Column Header -->
         <div
           v-if="connectionId"
-          class="bg-muted flex-shrink-0 w-10 right-0 sticky z-10"
+          class="bg-muted flex-shrink-0 w-20 right-0 sticky z-10"
         >
-          <div class="flex h-8 items-center justify-center">
-            <span class="i-carbon-overflow-menu-vertical text-muted-foreground h-3.5 w-3.5" />
+          <div class="flex h-8 items-center justify-center px-2">
+            <span class="text-xs font-medium text-muted-foreground truncate">{{ $t('components.dataGrid.row.actions') }}</span>
           </div>
         </div>
       </div>
@@ -694,7 +694,7 @@ watch(() => [props.rows, props.columns], () => {
             <!-- Row Actions -->
             <div
               v-if="connectionId"
-              class="bg-background/80 flex flex-shrink-0 w-10 items-center right-0 justify-center sticky z-10"
+              class="bg-background/80 flex flex-shrink-0 w-20 items-center right-0 justify-center sticky z-10"
               @click.stop
             >
               <DropdownMenu>

--- a/src/composables/sqlCompletion/analyzer.ts
+++ b/src/composables/sqlCompletion/analyzer.ts
@@ -263,15 +263,22 @@ export function analyzeCompletionContext(text: string, offset: number): Completi
     tableRefs = extractTableRefs(text, span.start, span.end)
   }
 
-  // activeTable: alias match on qualifier first; else last FROM/JOIN table.
+  // activeTable: alias/table match on a single-segment qualifier (`u.`, `users.`);
+  // otherwise the last FROM/JOIN table as the bare-column context table. A
+  // qualifier matching neither an alias nor a table (e.g. `public.us`) must NOT
+  // fall back to a FROM table — the builder would return that table's columns
+  // instead of the schema/table objects the user is completing.
   let activeTable: TableRef | null = null
   if (isAfterDot && tableRefs.length > 0) {
-    const firstQualSeg = qualifier.split('.')[0]
-    const byAlias = tableRefs.find(r => r.alias && r.alias.toLowerCase() === firstQualSeg.toLowerCase())
-    const byName = tableRefs.find(r => r.table.toLowerCase() === firstQualSeg.toLowerCase())
-    activeTable = byAlias ?? byName ?? null
+    const segments = qualifier.split('.').filter(Boolean)
+    if (segments.length === 1) {
+      const firstQualSeg = unquote(segments[0])
+      const byAlias = tableRefs.find(r => r.alias && r.alias.toLowerCase() === firstQualSeg.toLowerCase())
+      const byName = tableRefs.find(r => r.table.toLowerCase() === firstQualSeg.toLowerCase())
+      activeTable = byAlias ?? byName ?? null
+    }
   }
-  if (!activeTable && tableRefs.length > 0) {
+  if (!activeTable && !isAfterDot && tableRefs.length > 0) {
     activeTable = tableRefs[tableRefs.length - 1]
   }
 

--- a/src/composables/sqlCompletion/analyzer.ts
+++ b/src/composables/sqlCompletion/analyzer.ts
@@ -1,0 +1,286 @@
+/**
+ * ContextAnalyzer (Layer 1) — lexical analysis of the document at the cursor.
+ *
+ * Deliberately NOT a SQL parser: it uses regex/scanning to answer the only
+ * questions the builder needs:
+ *   - what word is being typed
+ *   - are we after a qualifier dot (alias./schema./db.schema.)
+ *   - which tables are referenced in the current statement (FROM/JOIN) with aliases
+ *   - is the cursor inside a comment (→ no suggestions)
+ *
+ * Pure module — no monaco/tauri imports (jest node-testable).
+ */
+
+import type { CompletionContext, TableRef } from './types'
+
+// Identifier: unicode letters/digits/_/$ plus dots for qualified names, and
+// double-quoted / backtick-quoted segments (e.g. "my table", `my-table`).
+const IDENT_CHAR = /[\p{L}\p{N}_$]/u
+const QUOTE_CHARS = ['"', '`']
+
+type StatementSpan = { start: number, end: number }
+
+/**
+ * Split the document into statements on ; while tracking quotes and comments,
+ * returning the span containing `offset`.
+ */
+function findContainingStatement(text: string, offset: number): StatementSpan {
+  const state = { quote: '', inLineComment: false, inBlockComment: false }
+  let stmtStart = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    const next = text[i + 1]
+
+    if (state.inLineComment) {
+      if (ch === '\n') {
+        state.inLineComment = false
+      }
+    }
+    else if (state.inBlockComment) {
+      if (ch === '*' && next === '/') {
+        state.inBlockComment = false
+        i++
+      }
+    }
+    else if (state.quote) {
+      if (ch === state.quote) {
+        if (next === state.quote) {
+          i++ // escaped quote inside identifier
+        }
+        else {
+          state.quote = ''
+        }
+      }
+    }
+    else if (ch === '-' && next === '-') {
+      state.inLineComment = true
+      i++
+    }
+    else if (ch === '/' && next === '*') {
+      state.inBlockComment = true
+      i++
+    }
+    else if (QUOTE_CHARS.includes(ch)) {
+      state.quote = ch
+    }
+    else if (ch === ';') {
+      // Statement boundary — but only if the offset is past it.
+      if (offset >= i) {
+        stmtStart = i + 1
+      }
+      else {
+        return { start: stmtStart, end: i }
+      }
+    }
+  }
+
+  return { start: stmtStart, end: text.length }
+}
+
+/** True when `offset` is inside a line/block comment (already statement-scoped). */
+function isInsideComment(text: string, start: number, _end: number, offset: number): boolean {
+  const prefix = text.slice(start, offset)
+  let inLine = false
+  let inBlock = false
+  let quote = ''
+
+  for (let i = 0; i < prefix.length; i++) {
+    const ch = prefix[i]
+    const next = prefix[i + 1]
+    if (inLine) {
+      if (ch === '\n')
+        inLine = false
+    }
+    else if (inBlock) {
+      if (ch === '*' && next === '/') {
+        inBlock = false
+        i++
+      }
+    }
+    else if (quote) {
+      if (ch === quote) {
+        if (next === quote)
+          i++
+        else
+          quote = ''
+      }
+    }
+    else if (ch === '-' && next === '-') {
+      inLine = true
+      i++
+    }
+    else if (ch === '/' && next === '*') {
+      inBlock = true
+      i++
+    }
+    else if (QUOTE_CHARS.includes(ch)) {
+      quote = ch
+    }
+  }
+  return inLine || inBlock
+}
+
+/** Strip quotes from a quoted identifier and collapse doubled quote chars. */
+function unquote(name: string): string {
+  if (name.length >= 2 && QUOTE_CHARS.includes(name[0]) && name[name.length - 1] === name[0]) {
+    const q = name[0]
+    const inner = name.slice(1, -1)
+    return inner.split(q + q).join(q)
+  }
+  return name
+}
+
+/** Replace comment spans with spaces (same length) so regex scanning skips them. */
+function maskComments(text: string, start: number, end: number): string {
+  const out = text.split('')
+  let inLine = false
+  let inBlock = false
+  let quote = ''
+  for (let i = start; i < end; i++) {
+    const ch = text[i]
+    const next = text[i + 1]
+    if (inLine) {
+      out[i] = ' '
+      if (ch === '\n')
+        inLine = false
+    }
+    else if (inBlock) {
+      out[i] = ' '
+      if (ch === '*' && next === '/') {
+        out[i + 1] = ' '
+        inBlock = false
+        i++
+      }
+    }
+    else if (quote) {
+      if (ch === quote) {
+        if (next === quote) {
+          i++
+        }
+        else {
+          quote = ''
+        }
+      }
+    }
+    else if (ch === '-' && next === '-') {
+      inLine = true
+      out[i] = ' '
+      out[i + 1] = ' '
+      i++
+    }
+    else if (ch === '/' && next === '*') {
+      inBlock = true
+      out[i] = ' '
+      out[i + 1] = ' '
+      i++
+    }
+    else if (QUOTE_CHARS.includes(ch)) {
+      quote = ch
+    }
+  }
+  return out.join('')
+}
+
+/**
+ * Extract table references from a statement via FROM/JOIN scanning.
+ * Comments are masked first so `-- FROM foo` never yields a table ref.
+ * Handles: FROM t, FROM t alias, FROM t AS alias, FROM schema.t, quoted names,
+ * JOIN variants.
+ */
+function extractTableRefs(text: string, start: number, end: number): TableRef[] {
+  const refs: TableRef[] = []
+  const stmt = maskComments(text, start, end).slice(start, end)
+  // Match FROM/JOIN followed by a (possibly quoted/qualified) identifier,
+  // with an optional AS-alias or bare alias.
+  const re = /\b(?:from|join)\s+((?:"[^"]*"|`[^`]*`|[\p{L}\p{N}_$]+)(?:\s*\.\s*(?:"[^"]*"|`[^`]*`|[\p{L}\p{N}_$]+))*)\s*(?:as\s+)?([\p{L}\p{N}_$]+)?/giu
+  let m: RegExpExecArray | null
+  while (true) {
+    m = re.exec(stmt)
+    if (m === null)
+      break
+    const rawName = m[1].trim()
+    const rawAlias = m[2]
+
+    // Parse schema.table / table out of the raw name (respecting quotes).
+    const parts = rawName.match(/"[^"]*"|`[^`]*`|[\p{L}\p{N}_$]+/gu) ?? []
+    const names = parts.map(unquote)
+    const table = names.length > 0 ? names[names.length - 1] : ''
+    const schema = names.length > 1 ? names[names.length - 2] : undefined
+    if (!table)
+      continue
+
+    const alias = rawAlias ? unquote(rawAlias) : undefined
+    // A bare-alias capture that is actually a keyword (e.g. `FROM a JOIN b`
+    // grabbing 'JOIN') means there is no alias — rewind so the next FROM/JOIN
+    // in the statement is matched.
+    if (alias && /^(?:on|where|group|order|having|limit|offset|union|set|values|select|left|right|inner|outer|join|as|and|or|not|when|then|else|end)$/i.test(alias)) {
+      refs.push({ table, schema })
+      re.lastIndex = m.index + rawName.length + 1
+      continue
+    }
+
+    refs.push({ table, schema, alias })
+  }
+  return refs
+}
+
+/**
+ * Analyze the document at `offset` and produce the completion context.
+ *
+ * @param text full document text
+ * @param offset character offset of the cursor
+ */
+export function analyzeCompletionContext(text: string, offset: number): CompletionContext {
+  const clampedOffset = Math.max(0, Math.min(offset, text.length))
+  const span = findContainingStatement(text, clampedOffset)
+  const inComment = isInsideComment(text, span.start, span.end, clampedOffset)
+
+  // Word being typed: scan backwards from cursor over identifier chars.
+  let wordStart = clampedOffset
+  while (wordStart > span.start && IDENT_CHAR.test(text[wordStart - 1])) {
+    wordStart--
+  }
+  const word = text.slice(wordStart, clampedOffset)
+
+  // Qualifier: scan backwards over `word.` / `schema.` / `db.schema.` segments.
+  let qualifier = ''
+  let qualifierStart = wordStart
+  while (true) {
+    // Skip optional whitespace? No — qualifiers are adjacent: `u.` or `db.`.
+    const before = text.slice(span.start, qualifierStart)
+    const m = before.match(/(?:"[^"]*"|`[^`]*`|[\p{L}\p{N}_$]+)\s*\.\s*$/u)
+    if (!m)
+      break
+    const segStart = qualifierStart - m[0].length
+    qualifier = text.slice(segStart, wordStart) // includes trailing dot(s)
+    qualifierStart = segStart
+  }
+  const isAfterDot = qualifier.length > 0
+
+  let tableRefs: TableRef[] = []
+  if (!inComment) {
+    tableRefs = extractTableRefs(text, span.start, span.end)
+  }
+
+  // activeTable: alias match on qualifier first; else last FROM/JOIN table.
+  let activeTable: TableRef | null = null
+  if (isAfterDot && tableRefs.length > 0) {
+    const firstQualSeg = qualifier.split('.')[0]
+    const byAlias = tableRefs.find(r => r.alias && r.alias.toLowerCase() === firstQualSeg.toLowerCase())
+    const byName = tableRefs.find(r => r.table.toLowerCase() === firstQualSeg.toLowerCase())
+    activeTable = byAlias ?? byName ?? null
+  }
+  if (!activeTable && tableRefs.length > 0) {
+    activeTable = tableRefs[tableRefs.length - 1]
+  }
+
+  return {
+    word,
+    tableRefs,
+    activeTable,
+    qualifier,
+    isAfterDot,
+    inComment,
+  }
+}

--- a/src/composables/sqlCompletion/builder.ts
+++ b/src/composables/sqlCompletion/builder.ts
@@ -1,0 +1,207 @@
+/**
+ * SuggestionBuilder (Layer 3) — pure assembly of completion suggestions.
+ *
+ * Input: CompletionContext + SchemaSnapshot + DialectProfile + host context.
+ * Output: Suggestion[] — no I/O, no monaco, no document access.
+ */
+
+import type { ColumnSuggestion, CompletionContext, DialectProfile, SchemaSnapshot, Suggestion, TableRef } from './types'
+
+const MAX_SUGGESTIONS = 100
+
+export type BuilderOptions = {
+  connectionId: string
+  currentDb: string | null
+  currentSchema: string | null
+}
+
+const ORDER: Record<Suggestion['kind'], number> = {
+  keyword: 0,
+  function: 1,
+  type: 2,
+  table: 3,
+  column: 4,
+  schema: 5,
+  database: 6,
+}
+
+function matchesPrefix(label: string, word: string): boolean {
+  return label.toLowerCase().startsWith(word.toLowerCase())
+}
+
+/** Rank: exact prefix match (word at start) ranks higher than contains; sortPrefix breaks ties. */
+function compareSuggestions(a: Suggestion, b: Suggestion): number {
+  const orderDiff = ORDER[a.kind] - ORDER[b.kind]
+  if (orderDiff !== 0)
+    return orderDiff
+  const sortDiff = (a.sortPrefix ?? 0) - (b.sortPrefix ?? 0)
+  if (sortDiff !== 0)
+    return sortDiff
+  return a.label.localeCompare(b.label)
+}
+
+function keywordSuggestions(word: string, dialect: DialectProfile): Suggestion[] {
+  const lower = word.toLowerCase()
+  return dialect.keywords
+    .filter(k => k.toLowerCase().startsWith(lower))
+    .map(k => ({ label: k, kind: 'keyword' as const, insertText: k }))
+}
+
+function functionSuggestions(word: string, dialect: DialectProfile): Suggestion[] {
+  const lower = word.toLowerCase()
+  return dialect.functions
+    .filter(f => f.toLowerCase().startsWith(lower))
+    .map(f => ({
+      label: f,
+      kind: 'function' as const,
+      insertText: dialect.noParenFunctions.includes(f) ? f : `${f}()`,
+    }))
+}
+
+function typeSuggestions(word: string, dialect: DialectProfile): Suggestion[] {
+  const lower = word.toLowerCase()
+  return dialect.types
+    .filter(t => t.toLowerCase().startsWith(lower))
+    .map(t => ({ label: t, kind: 'type' as const, insertText: t }))
+}
+
+/**
+ * Build completion suggestions for the given context.
+ *
+ * - After a dot → only object suggestions (columns of the active table when
+ *   the qualifier is an alias/table; tables of a schema/db; databases when
+ *   no qualifier match). No keywords after a dot.
+ * - Otherwise → keywords + functions + types + tables + schemas + databases.
+ */
+export function buildSuggestions(
+  ctx: CompletionContext,
+  snapshot: SchemaSnapshot,
+  dialect: DialectProfile,
+  opts: BuilderOptions,
+): Suggestion[] {
+  if (ctx.inComment)
+    return []
+
+  if (ctx.isAfterDot) {
+    return buildObjectSuggestions(ctx, snapshot, dialect, opts).slice(0, MAX_SUGGESTIONS)
+  }
+
+  // With an empty word, keyword/function/type suggestions are noise (they would
+  // all match); only object names are useful, e.g. tables right after FROM.
+  const lexical: Suggestion[] = ctx.word === ''
+    ? []
+    : [
+        ...keywordSuggestions(ctx.word, dialect),
+        ...functionSuggestions(ctx.word, dialect),
+        ...typeSuggestions(ctx.word, dialect),
+      ]
+  const suggestions: Suggestion[] = [
+    ...lexical,
+    ...buildTableSuggestions(ctx, snapshot, opts),
+    ...buildSchemaSuggestions(ctx, snapshot, opts),
+    ...buildDatabaseSuggestions(ctx, snapshot),
+  ]
+  return suggestions.sort(compareSuggestions).slice(0, MAX_SUGGESTIONS)
+}
+
+function buildObjectSuggestions(
+  ctx: CompletionContext,
+  snapshot: SchemaSnapshot,
+  dialect: DialectProfile,
+  opts: BuilderOptions,
+): Suggestion[] {
+  const segments = ctx.qualifier.split('.').filter(Boolean)
+  const first = segments[0] ?? ''
+
+  // `alias.` or `table.` → columns of that table.
+  const active = ctx.activeTable
+  if (active) {
+    const realName = snapshot.derivedTables[active.table] ?? active.table
+    const columns = collectColumns(snapshot, opts.connectionId, opts.currentDb, opts.currentSchema, { ...active, table: realName })
+    if (columns.length > 0) {
+      return columns
+        .filter(c => matchesPrefix(c.name, ctx.word))
+        .map(c => ({
+          label: c.name,
+          kind: 'column' as const,
+          insertText: c.name,
+          detail: c.dataType,
+          documentation: c.isPrimaryKey ? 'Primary key' : undefined,
+        }))
+        .sort(compareSuggestions)
+    }
+  }
+
+  // `schema.` → tables of that schema (or db when no schema support).
+  if (first && snapshot.hasSchemaData) {
+    const db = opts.currentDb ?? snapshot.databases[0]?.name ?? ''
+    if (db) {
+      const schemaKey = dialect.supportsSchemaQualification && opts.currentSchema
+        ? `${db}.${first}`
+        : db
+      const tables = snapshot.tablesByKey[schemaKey] ?? snapshot.tablesByKey[db] ?? []
+      const filtered = tables.filter(t => matchesPrefix(t, ctx.word))
+      if (filtered.length > 0 || segments.length >= 2) {
+        return filtered
+          .map(t => ({ label: t, kind: 'table' as const, insertText: t }))
+          .sort(compareSuggestions)
+      }
+    }
+  }
+
+  // `db.` → schemas.
+  if (segments.length === 1) {
+    const schemas = snapshot.schemasByDb[first] ?? []
+    return schemas
+      .filter(s => matchesPrefix(s, ctx.word))
+      .map(s => ({ label: s, kind: 'schema' as const, insertText: s }))
+      .sort(compareSuggestions)
+  }
+
+  return []
+}
+
+function collectColumns(
+  snapshot: SchemaSnapshot,
+  connectionId: string,
+  currentDb: string | null,
+  currentSchema: string | null,
+  active: TableRef,
+): ColumnSuggestion[] {
+  const db = currentDb ?? snapshot.databases[0]?.name ?? ''
+  if (!db)
+    return []
+  const schema = active.schema ?? currentSchema ?? ''
+  const key = `${connectionId}|${db}|${schema}|${active.table}`
+  return snapshot.columnsByTable[key] ?? []
+}
+
+function buildTableSuggestions(ctx: CompletionContext, snapshot: SchemaSnapshot, opts: BuilderOptions): Suggestion[] {
+  if (!snapshot.hasSchemaData)
+    return []
+  const db = opts.currentDb ?? snapshot.databases[0]?.name ?? ''
+  if (!db)
+    return []
+  const key = opts.currentSchema && snapshot.tablesByKey[`${db}.${opts.currentSchema}`]
+    ? `${db}.${opts.currentSchema}`
+    : db
+  const tables = snapshot.tablesByKey[key] ?? snapshot.tablesByKey[db] ?? []
+  return tables
+    .filter(t => matchesPrefix(t, ctx.word))
+    .map(t => ({ label: t, kind: 'table' as const, insertText: t }))
+}
+
+function buildSchemaSuggestions(ctx: CompletionContext, snapshot: SchemaSnapshot, opts: BuilderOptions): Suggestion[] {
+  const db = opts.currentDb ?? snapshot.databases[0]?.name ?? ''
+  if (!db)
+    return []
+  return (snapshot.schemasByDb[db] ?? [])
+    .filter(s => matchesPrefix(s, ctx.word))
+    .map(s => ({ label: s, kind: 'schema' as const, insertText: s }))
+}
+
+function buildDatabaseSuggestions(ctx: CompletionContext, snapshot: SchemaSnapshot): Suggestion[] {
+  return snapshot.databases
+    .filter(d => matchesPrefix(d.name, ctx.word))
+    .map(d => ({ label: d.name, kind: 'database' as const, insertText: d.name }))
+}

--- a/src/composables/sqlCompletion/dialects.ts
+++ b/src/composables/sqlCompletion/dialects.ts
@@ -1,0 +1,259 @@
+/**
+ * Dialect profiles + formatter→monaco dialect mapping.
+ *
+ * Single source of truth for SQL keywords/types/functions (migrated from
+ * useMonacoEditor.ts) and for converging per-dialect differences as DATA
+ * (quote char, schema qualification) instead of code branches.
+ *
+ * Pure module — no monaco/tauri imports (jest node-testable).
+ */
+
+import type { DialectProfile, SQLDialect } from './types'
+import { GRAMMAR_DIALECTS } from './types'
+
+// ── SQL keywords / types / functions (migrated verbatim from useMonacoEditor.ts) ──
+
+export const SQL_KEYWORDS: string[] = [
+  'SELECT',
+  'FROM',
+  'WHERE',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'CREATE',
+  'ALTER',
+  'DROP',
+  'TABLE',
+  'INDEX',
+  'VIEW',
+  'DATABASE',
+  'SCHEMA',
+  'JOIN',
+  'INNER',
+  'LEFT',
+  'RIGHT',
+  'OUTER',
+  'ON',
+  'AS',
+  'AND',
+  'OR',
+  'NOT',
+  'NULL',
+  'IS',
+  'IN',
+  'BETWEEN',
+  'LIKE',
+  'ORDER',
+  'BY',
+  'GROUP',
+  'HAVING',
+  'LIMIT',
+  'OFFSET',
+  'UNION',
+  'DISTINCT',
+  'COUNT',
+  'SUM',
+  'AVG',
+  'MAX',
+  'MIN',
+  'CAST',
+  'CASE',
+  'WHEN',
+  'THEN',
+  'ELSE',
+  'END',
+  'PRIMARY',
+  'KEY',
+  'FOREIGN',
+  'REFERENCES',
+  'CONSTRAINT',
+  'UNIQUE',
+  'CHECK',
+  'DEFAULT',
+  'AUTO_INCREMENT',
+  'CASCADE',
+  'SET',
+  'VALUES',
+  'INTO',
+  'BEGIN',
+  'COMMIT',
+  'ROLLBACK',
+  'TRANSACTION',
+  'SAVEPOINT',
+  'TRUNCATE',
+  'GRANT',
+  'REVOKE',
+  'WITH',
+  'RECURSIVE',
+  'WINDOW',
+  'PARTITION',
+  'OVER',
+  'ROW_NUMBER',
+  'RANK',
+  'DENSE_RANK',
+]
+
+export const SQL_TYPES: string[] = [
+  'INT',
+  'INTEGER',
+  'BIGINT',
+  'SMALLINT',
+  'TINYINT',
+  'DECIMAL',
+  'NUMERIC',
+  'FLOAT',
+  'REAL',
+  'DOUBLE',
+  'CHAR',
+  'VARCHAR',
+  'TEXT',
+  'NCHAR',
+  'NVARCHAR',
+  'NTEXT',
+  'DATE',
+  'TIME',
+  'DATETIME',
+  'TIMESTAMP',
+  'YEAR',
+  'BOOLEAN',
+  'BOOL',
+  'BINARY',
+  'VARBINARY',
+  'BLOB',
+  'CLOB',
+  'JSON',
+  'UUID',
+  'SERIAL',
+  'BIGSERIAL',
+]
+
+export const SQL_FUNCTIONS: string[] = [
+  'CONCAT',
+  'SUBSTRING',
+  'UPPER',
+  'LOWER',
+  'TRIM',
+  'LTRIM',
+  'RTRIM',
+  'LENGTH',
+  'REPLACE',
+  'COALESCE',
+  'NULLIF',
+  'IFNULL',
+  'NOW',
+  'CURRENT_DATE',
+  'CURRENT_TIME',
+  'CURRENT_TIMESTAMP',
+  'DATE_ADD',
+  'DATE_SUB',
+  'DATEDIFF',
+  'EXTRACT',
+  'TO_CHAR',
+  'TO_DATE',
+  'TO_NUMBER',
+  'ROUND',
+  'CEIL',
+  'FLOOR',
+  'ABS',
+  'SIGN',
+  'MOD',
+  'POWER',
+  'SQRT',
+  'EXP',
+  'LN',
+  'LOG',
+]
+
+export const NO_PAREN_FUNCTIONS: string[] = [
+  'NOW',
+  'CURRENT_DATE',
+  'CURRENT_TIME',
+  'CURRENT_TIMESTAMP',
+]
+
+// ── Dialect profiles ──
+
+const BASE_PROFILE = {
+  keywords: SQL_KEYWORDS,
+  functions: SQL_FUNCTIONS,
+  types: SQL_TYPES,
+  noParenFunctions: NO_PAREN_FUNCTIONS,
+}
+
+/** Full profiles for dialects with monaco grammar; others reuse the 'sql' profile. */
+export const DIALECT_PROFILES: Record<SQLDialect, DialectProfile> = {
+  sql: {
+    id: 'sql',
+    quoteChar: '"',
+    supportsSchemaQualification: true,
+    ...BASE_PROFILE,
+  },
+  pgsql: {
+    id: 'pgsql',
+    quoteChar: '"',
+    supportsSchemaQualification: true,
+    ...BASE_PROFILE,
+  },
+  mysql: {
+    id: 'mysql',
+    quoteChar: '`',
+    supportsSchemaQualification: true,
+    ...BASE_PROFILE,
+  },
+  // mssql/plsql/sqlite: completion registered for these ids (future grammar),
+  // but they reuse the generic profile until real dialect data is added.
+  mssql: {
+    id: 'mssql',
+    quoteChar: '"',
+    supportsSchemaQualification: true,
+    ...BASE_PROFILE,
+  },
+  plsql: {
+    id: 'plsql',
+    quoteChar: '"',
+    supportsSchemaQualification: true,
+    ...BASE_PROFILE,
+  },
+  sqlite: {
+    id: 'sqlite',
+    quoteChar: '"',
+    supportsSchemaQualification: false,
+    ...BASE_PROFILE,
+  },
+}
+
+export function getDialectProfile(id: SQLDialect): DialectProfile {
+  return DIALECT_PROFILES[id]
+}
+
+/** True when the dialect id has a monaco grammar contribution (highlighting). */
+export function hasGrammar(id: SQLDialect): boolean {
+  return GRAMMAR_DIALECTS.includes(id)
+}
+
+// ── formatter dialect → monaco dialect mapping ──
+// resolveDialect() (useSqlFormatter) returns sql-formatter ids; the editor needs
+// monaco language ids. Unmapped ids fall back to 'sql' (generic).
+
+const FORMATTER_TO_MONACO: Record<string, SQLDialect> = {
+  // PostgreSQL family
+  postgresql: 'pgsql',
+  redshift: 'pgsql',
+  // MySQL family
+  mysql: 'mysql',
+  mariadb: 'mysql',
+  tidb: 'mysql',
+  // SQL Server family
+  tsql: 'mssql',
+  // Oracle family
+  plsql: 'plsql',
+  oracle: 'plsql',
+  // SQLite
+  sqlite: 'sqlite',
+  // Everything else → generic 'sql' (trino, hive, spark, bigquery, db2,
+  // duckdb, clickhouse, snowflake, hana, teradata, exasol, ...)
+}
+
+export function resolveMonacoDialect(formatterId: string): SQLDialect {
+  return FORMATTER_TO_MONACO[formatterId] ?? 'sql'
+}

--- a/src/composables/sqlCompletion/metadata.ts
+++ b/src/composables/sqlCompletion/metadata.ts
@@ -149,6 +149,11 @@ export class SchemaMetadataService {
    * Prefetch columns for the given tables, chunked at `concurrency` in-flight
    * invokes, capped at `maxTables` tables per call. Never throws: failures
    * leave the affected cache keys absent.
+   *
+   * Only the caller-provided `schema` gets cached. Completion for
+   * schema-qualified refs to other schemas (e.g. `FROM public.users` while
+   * `dbo` is the active schema) therefore misses silently — acceptable for the
+   * sync provider; `fetchTableColumns()` on a miss is the async escape.
    */
   async prefetchColumns(connectionId: string, database: string, schema: string | undefined, tableNames: string[]): Promise<void> {
     const targets = tableNames.slice(0, this.maxTables)

--- a/src/composables/sqlCompletion/metadata.ts
+++ b/src/composables/sqlCompletion/metadata.ts
@@ -1,0 +1,242 @@
+/**
+ * SchemaMetadataService (Layer 2) — 3-level schema cache.
+ *
+ * Level A (connection-level): databases/schemas/tables — read from the app's
+ *   databaseStore via an injected getter (tests inject fakes; the default
+ *   reads the real Pinia store lazily).
+ * Level B (object-level): column cache — module-local Map filled by
+ *   prefetchColumns() (chunked, concurrency-capped) or lazily by getColumns().
+ * Level C (derived, v1): document aliases/CTEs → real table names, injected
+ *   by the caller (setDerivedTables).
+ *
+ * Never writes to databaseStore; never persists; never throws on missing data
+ * (returns empty). Pure-ish module: the only tauri dependency is `invoke`,
+ * isolated so tests can mock it.
+ */
+
+import type { ColumnSuggestion } from './types'
+import { invoke } from '@tauri-apps/api/core'
+
+export type ColumnInfo = {
+  name: string
+  data_type: string
+  nullable: boolean
+  default_value?: string
+  is_primary_key: boolean
+  is_auto_increment: boolean
+  max_length?: number
+  precision?: number
+  scale?: number
+  description?: string
+  metadata?: Record<string, string>
+}
+
+/** Minimal view of the app store's metadata that this service consumes. */
+export type StoreMetadata = {
+  databases: { name: string, is_system: boolean }[]
+  schemas: Record<string, string[]>
+  tables: Record<string, { name: string, schema?: string }[]>
+}
+
+export type MetadataGetter = (connectionId: string) => StoreMetadata | null
+
+const DEFAULT_MAX_TABLES = 100
+const DEFAULT_CONCURRENCY = 5
+
+/**
+ * The Pinia store accessor, registered once by app wiring (main.ts) so this
+ * module never statically imports the store — keeps it loadable in jest
+ * without Pinia, and browser-safe (no CommonJS `require`).
+ */
+let storeLoader: (() => typeof import('@/store/databaseStore')['useDatabaseStore']) | null = null
+
+/** Register the database-store accessor (app bootstrap). Null disables (tests). */
+export function setDatabaseStoreLoader(
+  loader: (() => typeof import('@/store/databaseStore')['useDatabaseStore']) | null,
+) {
+  storeLoader = loader
+}
+
+const DEFAULT_GETTER: MetadataGetter = (connectionId) => {
+  const useStore = storeLoader?.()
+  if (!useStore)
+    return null
+  const store = useStore()
+  const meta = store.metadata[connectionId]
+  if (!meta)
+    return null
+  return {
+    databases: meta.databases,
+    schemas: meta.schemas,
+    tables: meta.tables,
+  }
+}
+
+function columnKey(connId: string, database: string, schema: string | undefined, table: string): string {
+  return `${connId}|${database}|${schema ?? ''}|${table}`
+}
+
+function toColumnSuggestion(col: ColumnInfo): ColumnSuggestion {
+  return {
+    name: col.name,
+    dataType: col.data_type,
+    isPrimaryKey: col.is_primary_key,
+  }
+}
+
+export class SchemaMetadataService {
+  private columns = new Map<string, ColumnSuggestion[]>()
+  private derivedTables = new Map<string, string>()
+  private readonly maxTables: number
+  private readonly concurrency: number
+  private readonly getMetadata: MetadataGetter
+
+  constructor(opts: {
+    getMetadata?: MetadataGetter
+    maxTables?: number
+    concurrency?: number
+  } = {}) {
+    this.getMetadata = opts.getMetadata ?? DEFAULT_GETTER
+    this.maxTables = opts.maxTables ?? DEFAULT_MAX_TABLES
+    this.concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY
+  }
+
+  // ── Level A: connection-level objects (from the app store) ──
+
+  getDatabases(connectionId: string): { name: string, isSystem: boolean }[] {
+    const meta = this.getMetadata(connectionId)
+    if (!meta)
+      return []
+    return meta.databases.map(db => ({ name: db.name, isSystem: db.is_system }))
+  }
+
+  getSchemas(connectionId: string, database: string): string[] {
+    const meta = this.getMetadata(connectionId)
+    return meta?.schemas[database] ?? []
+  }
+
+  getTables(connectionId: string, database: string, schema?: string): string[] {
+    const meta = this.getMetadata(connectionId)
+    if (!meta)
+      return []
+    const key = schema ? `${database}.${schema}` : database
+    const tables = meta.tables[key]
+    if (!tables)
+      return []
+    return tables.map(t => t.name)
+  }
+
+  /** Resolve a document alias/CTE name to a real table name (Level C). */
+  resolveDerived(name: string): string | undefined {
+    return this.derivedTables.get(name)
+  }
+
+  setDerivedTables(entries: Record<string, string>) {
+    this.derivedTables = new Map(Object.entries(entries))
+  }
+
+  // ── Level B: column cache ──
+
+  getColumns(connectionId: string, database: string, schema: string | undefined, table: string): ColumnSuggestion[] {
+    const key = columnKey(connectionId, database, schema, table)
+    const cached = this.columns.get(key)
+    if (cached)
+      return cached
+    return []
+  }
+
+  /**
+   * Prefetch columns for the given tables, chunked at `concurrency` in-flight
+   * invokes, capped at `maxTables` tables per call. Never throws: failures
+   * leave the affected cache keys absent.
+   */
+  async prefetchColumns(connectionId: string, database: string, schema: string | undefined, tableNames: string[]): Promise<void> {
+    const targets = tableNames.slice(0, this.maxTables)
+    for (let i = 0; i < targets.length; i += this.concurrency) {
+      const chunk = targets.slice(i, i + this.concurrency)
+      await Promise.all(chunk.map(table => this.fetchAndCache(connectionId, database, schema, table)))
+    }
+  }
+
+  /** Lazily fetch one table's columns on demand (used on cache miss). */
+  async fetchTableColumns(connectionId: string, database: string, schema: string | undefined, table: string): Promise<ColumnSuggestion[]> {
+    return this.fetchAndCache(connectionId, database, schema, table)
+  }
+
+  private async fetchAndCache(
+    connectionId: string,
+    database: string,
+    schema: string | undefined,
+    table: string,
+  ): Promise<ColumnSuggestion[]> {
+    const key = columnKey(connectionId, database, schema, table)
+    const cached = this.columns.get(key)
+    if (cached)
+      return cached
+
+    try {
+      const result = await invoke<ColumnInfo[]>('list_columns', {
+        connectionId,
+        database,
+        schema,
+        tableName: table,
+      })
+      const suggestions = (result ?? []).map(toColumnSuggestion)
+      this.columns.set(key, suggestions)
+      return suggestions
+    }
+    catch (error) {
+      console.error(`[sqlCompletion] failed to load columns for ${database}.${table}:`, error)
+      return []
+    }
+  }
+
+  /** Remove cached columns for one connection (or all when connId omitted). */
+  clearColumnCache(connectionId?: string) {
+    if (connectionId === undefined) {
+      this.columns.clear()
+      return
+    }
+    const prefix = `${connectionId}|`
+    for (const key of this.columns.keys()) {
+      if (key.startsWith(prefix)) {
+        this.columns.delete(key)
+      }
+    }
+  }
+
+  /** Snapshot the column cache for one connection (or all when connId omitted). */
+  getCachedColumns(connectionId?: string): Record<string, ColumnSuggestion[]> {
+    if (connectionId === undefined) {
+      return Object.fromEntries(this.columns)
+    }
+    const prefix = `${connectionId}|`
+    const out: Record<string, ColumnSuggestion[]> = {}
+    for (const [key, cols] of this.columns) {
+      if (key.startsWith(prefix)) {
+        out[key] = cols
+      }
+    }
+    return out
+  }
+
+  clearAll() {
+    this.columns.clear()
+    this.derivedTables.clear()
+  }
+}
+
+/** Module-level singleton used by the provider and page wiring. */
+let instance: SchemaMetadataService | null = null
+
+export function getMetadataService(): SchemaMetadataService {
+  if (!instance) {
+    instance = new SchemaMetadataService()
+  }
+  return instance
+}
+
+/** Test hook: replace the singleton (e.g. with a fake-getter instance). */
+export function setMetadataServiceForTests(service: SchemaMetadataService | null) {
+  instance = service
+}

--- a/src/composables/sqlCompletion/provider.ts
+++ b/src/composables/sqlCompletion/provider.ts
@@ -197,8 +197,8 @@ export type CompletionProvider = ReturnType<typeof createProvider>
 let singleton: CompletionProvider | null = null
 let registrationDisposables: monaco.IDisposable[] | null = null
 
-/** Memoized singleton. Pass the real monaco on first call (from useMonacoEditor). */
-export function getCompletionProvider(monacoLike: typeof monaco = undefined as never): CompletionProvider {
+/** Memoized singleton. The real monaco must be passed on first call (from useMonacoEditor) to register providers. */
+export function getCompletionProvider(monacoLike: typeof monaco): CompletionProvider {
   if (!singleton) {
     const provider = createProvider(monacoLike, {
       metadataService: getMetadataService(),

--- a/src/composables/sqlCompletion/provider.ts
+++ b/src/composables/sqlCompletion/provider.ts
@@ -1,0 +1,226 @@
+/**
+ * CompletionProvider (Layer 4) — monaco-facing wiring.
+ *
+ * Singleton that registers a completion provider for every SQLDialect id.
+ * provideCompletionItems is fully SYNC (no per-keystroke backend call); only
+ * resolveCompletionItem is async (augments documentation, currently from
+ * in-memory snapshot — async signature reserved for a future LSP escape).
+ *
+ * The factory createProvider(monacoLike, deps) lets unit tests inject a fake
+ * monaco; the singleton uses the real monaco-editor ESM API.
+ */
+
+import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import type { SchemaMetadataService } from './metadata'
+import type { CompletionContextInput, SchemaSnapshot, SQLDialect, Suggestion } from './types'
+import { analyzeCompletionContext } from './analyzer'
+import { buildSuggestions } from './builder'
+import { getDialectProfile } from './dialects'
+import { getMetadataService } from './metadata'
+
+export const SQL_DIALECT_IDS: readonly SQLDialect[] = ['sql', 'mysql', 'pgsql', 'mssql', 'plsql', 'sqlite']
+
+/** Per-editor identity + snapshot, keyed by the backing ITextModel. */
+export type ModelContext = {
+  connId: string
+  database: string | null
+  schema: string | null
+  dialectId: SQLDialect
+  snapshot: SchemaSnapshot
+}
+
+export type ProviderDeps = {
+  metadataService: SchemaMetadataService
+  analyze: typeof analyzeCompletionContext
+  build: typeof buildSuggestions
+  profiles: typeof getDialectProfile
+}
+
+export function emptySnapshot(): SchemaSnapshot {
+  return {
+    databases: [],
+    schemasByDb: {},
+    tablesByKey: {},
+    columnsByTable: {},
+    derivedTables: {},
+    hasSchemaData: false,
+  }
+}
+
+export function createProvider(monacoLike: typeof monaco, deps: ProviderDeps) {
+  const KIND_MAP: Record<Suggestion['kind'], monaco.languages.CompletionItemKind> = {
+    keyword: monacoLike.languages.CompletionItemKind.Keyword,
+    function: monacoLike.languages.CompletionItemKind.Function,
+    type: monacoLike.languages.CompletionItemKind.TypeParameter,
+    table: monacoLike.languages.CompletionItemKind.Class,
+    column: monacoLike.languages.CompletionItemKind.Field,
+    schema: monacoLike.languages.CompletionItemKind.Module,
+    database: monacoLike.languages.CompletionItemKind.Folder,
+  }
+  const contexts = new WeakMap<monaco.editor.ITextModel, ModelContext>()
+
+  const makeSnapshot = (input: CompletionContextInput, metadata: SchemaMetadataService): SchemaSnapshot => {
+    const connId = input.connectionId ?? ''
+    const db = input.database ?? null
+    const schema = input.schema ?? null
+
+    const databases = metadata.getDatabases(connId)
+    const schemasByDb: Record<string, string[]> = {}
+    for (const d of databases) {
+      const schemas = metadata.getSchemas(connId, d.name)
+      if (schemas.length > 0) {
+        schemasByDb[d.name] = schemas
+      }
+    }
+
+    const tablesByKey: Record<string, string[]> = {}
+    const addTables = (key: string, tables: string[]) => {
+      if (tables.length > 0) {
+        tablesByKey[key] = tables
+      }
+    }
+    if (db) {
+      if (schema) {
+        addTables(`${db}.${schema}`, metadata.getTables(connId, db, schema))
+      }
+      else {
+        const unqualified = metadata.getTables(connId, db)
+        const qualified = metadata.getSchemas(connId, db).map(s => metadata.getTables(connId, db, s)).flat()
+        addTables(db, [...new Set([...unqualified, ...qualified])])
+      }
+    }
+
+    return {
+      databases,
+      schemasByDb,
+      tablesByKey,
+      columnsByTable: metadata.getCachedColumns(connId),
+      derivedTables: {},
+      hasSchemaData: databases.length > 0,
+    }
+  }
+
+  const provideCompletionItems = (
+    model: monaco.editor.ITextModel,
+    position: monaco.Position,
+  ): monaco.languages.CompletionList => {
+    if (!model || !position) {
+      return { suggestions: [] }
+    }
+    const modelCtx = contexts.get(model)
+    if (!modelCtx) {
+      return { suggestions: [] }
+    }
+
+    const offset = model.getOffsetAt(position)
+    const analysis = deps.analyze(model.getValue(), offset)
+    const dialect = deps.profiles(modelCtx.dialectId)
+    const suggestions = deps.build(analysis, modelCtx.snapshot, dialect, {
+      connectionId: modelCtx.connId,
+      currentDb: modelCtx.database,
+      currentSchema: modelCtx.schema,
+    })
+
+    const word = model.getWordUntilPosition(position)
+    const range = {
+      startLineNumber: position.lineNumber,
+      endLineNumber: position.lineNumber,
+      startColumn: word.startColumn,
+      endColumn: word.endColumn,
+    }
+
+    return {
+      suggestions: suggestions.map(s => ({
+        label: s.label,
+        kind: KIND_MAP[s.kind],
+        insertText: s.insertText,
+        detail: s.detail,
+        documentation: s.documentation,
+        range,
+      })),
+    }
+  }
+
+  const resolveCompletionItem = async (
+    item: monaco.languages.CompletionItem,
+  ): Promise<monaco.languages.CompletionItem> => {
+    return item
+  }
+
+  const register = (): monaco.IDisposable[] => {
+    return SQL_DIALECT_IDS.map(id =>
+      monacoLike.languages.registerCompletionItemProvider(id, {
+        provideCompletionItems,
+        resolveCompletionItem,
+      }),
+    )
+  }
+
+  const setContext = (model: monaco.editor.ITextModel | null, input: CompletionContextInput) => {
+    if (!model) {
+      return
+    }
+    const metadata = deps.metadataService
+    const connId = input.connectionId ?? ''
+    contexts.set(model, {
+      connId,
+      database: input.database ?? null,
+      schema: input.schema ?? null,
+      dialectId: input.dialectId ?? 'sql',
+      snapshot: makeSnapshot(input, metadata),
+    })
+  }
+
+  const clearModel = (model: monaco.editor.ITextModel | null) => {
+    if (model) {
+      contexts.delete(model)
+    }
+  }
+
+  const dispose = () => {
+    // contexts is a WeakMap; nothing to release eagerly.
+  }
+
+  return {
+    register,
+    setContext,
+    clearModel,
+    provideCompletionItems,
+    resolveCompletionItem,
+    dispose,
+    contexts,
+  }
+}
+
+export type CompletionProvider = ReturnType<typeof createProvider>
+
+let singleton: CompletionProvider | null = null
+let registrationDisposables: monaco.IDisposable[] | null = null
+
+/** Memoized singleton. Pass the real monaco on first call (from useMonacoEditor). */
+export function getCompletionProvider(monacoLike: typeof monaco = undefined as never): CompletionProvider {
+  if (!singleton) {
+    const provider = createProvider(monacoLike, {
+      metadataService: getMetadataService(),
+      analyze: analyzeCompletionContext,
+      build: buildSuggestions,
+      profiles: getDialectProfile,
+    })
+    registrationDisposables = provider.register()
+    singleton = {
+      ...provider,
+      register: () => registrationDisposables ?? [],
+      dispose: () => {
+        registrationDisposables?.forEach(d => d.dispose())
+        registrationDisposables = null
+        singleton = null
+      },
+    }
+  }
+  return singleton
+}
+
+export function disposeCompletionProvider() {
+  singleton?.dispose()
+  singleton = null
+}

--- a/src/composables/sqlCompletion/types.ts
+++ b/src/composables/sqlCompletion/types.ts
@@ -28,7 +28,7 @@ export type CompletionContext = {
   word: string
   /** The current statement's table references in order of appearance. */
   tableRefs: TableRef[]
-  /** Table the cursor is scoped to (alias match first, else last FROM/JOIN table). */
+  /** Table the cursor is scoped to: alias/table match on a single-segment qualifier, else the last FROM/JOIN table in bare-column context; null for unmatched schema/db qualifiers (`public.`). */
   activeTable: TableRef | null
   /** Qualifier prefix before the word, e.g. 'u.' or 'public.' or 'db.public.'. */
   qualifier: string

--- a/src/composables/sqlCompletion/types.ts
+++ b/src/composables/sqlCompletion/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Domain model for SQLKit's schema-aware autocompletion.
+ *
+ * This module is deliberately framework-free (no monaco, no tauri, no vue):
+ * it is imported by every other layer and must stay testable in a plain
+ * jest node environment.
+ */
+
+/** Monaco language ids SQLKit registers completion for. */
+export type SQLDialect = 'sql' | 'mysql' | 'pgsql' | 'mssql' | 'plsql' | 'sqlite'
+
+/** SQL dialects that ship a monaco grammar contribution (have highlighting). */
+export const GRAMMAR_DIALECTS: readonly SQLDialect[] = ['sql', 'mysql', 'pgsql']
+
+/** A table (or alias) referenced by the current statement. */
+export type TableRef = {
+  /** Table name, unquoted and normalized (case preserved). */
+  table: string
+  /** User-provided alias if any (`FROM users u` → 'u'). */
+  alias?: string
+  /** Schema qualifier if present (`FROM public.users` → 'public'). */
+  schema?: string
+}
+
+/** What the user is typing right now and where. */
+export type CompletionContext = {
+  /** The raw word being typed (already typed characters of the current identifier). */
+  word: string
+  /** The current statement's table references in order of appearance. */
+  tableRefs: TableRef[]
+  /** Table the cursor is scoped to (alias match first, else last FROM/JOIN table). */
+  activeTable: TableRef | null
+  /** Qualifier prefix before the word, e.g. 'u.' or 'public.' or 'db.public.'. */
+  qualifier: string
+  /** True when typing after a dot (only object suggestions should apply). */
+  isAfterDot: boolean
+  /** True when cursor is inside a comment (line or block) → no suggestions. */
+  inComment: boolean
+}
+
+/** Column metadata as surfaced for completion. */
+export type ColumnSuggestion = {
+  name: string
+  dataType?: string
+  isPrimaryKey?: boolean
+}
+
+/** A database. */
+export type DatabaseRef = {
+  name: string
+  isSystem: boolean
+}
+
+/** Schema-level view of a connection's objects (built from databaseStore + column cache). */
+export type SchemaSnapshot = {
+  databases: DatabaseRef[]
+  /** databases → schemas. */
+  schemasByDb: Record<string, string[]>
+  /** `db` or `db.schema` → tables. */
+  tablesByKey: Record<string, string[]>
+  /** `connId|db|schema|table` → columns. */
+  columnsByTable: Record<string, ColumnSuggestion[]>
+  /** Derived (document) tables: alias or CTE name → real table name. */
+  derivedTables: Record<string, string>
+  /** Whether the snapshot has any database-level data (false → keyword-only). */
+  hasSchemaData: boolean
+}
+
+export type SuggestionKind
+  = | 'keyword'
+    | 'function'
+    | 'type'
+    | 'table'
+    | 'column'
+    | 'schema'
+    | 'database'
+
+/** A single completion suggestion (layer-agnostic; mapped to monaco at the edge). */
+export type Suggestion = {
+  label: string
+  kind: SuggestionKind
+  insertText: string
+  detail?: string
+  documentation?: string
+  /** Higher = ranked earlier when labels tie. */
+  sortPrefix?: number
+}
+
+/** Per-dialect data used to converge grammar differences without code branches. */
+export type DialectProfile = {
+  id: SQLDialect
+  /** Character used to quote identifiers (`"` for pgsql/sql, backtick for mysql). */
+  quoteChar: string
+  /** Whether schema-qualified names (`schema.table`) are typical for this dialect. */
+  supportsSchemaQualification: boolean
+  keywords: string[]
+  functions: string[]
+  types: string[]
+  /** Functions inserted WITHOUT trailing parens (e.g. NOW, CURRENT_DATE). */
+  noParenFunctions: string[]
+}
+
+/** Completion context required from the host page (per editor/tab). */
+export type CompletionContextInput = {
+  connectionId?: string
+  database?: string | null
+  schema?: string | null
+  dialectId?: SQLDialect
+}

--- a/src/composables/useMonacoEditor.ts
+++ b/src/composables/useMonacoEditor.ts
@@ -5,6 +5,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
 
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import { onBeforeUnmount } from 'vue'
+import { hasGrammar } from './sqlCompletion/dialects'
 import { getCompletionProvider } from './sqlCompletion/provider'
 import {
   getSqlGutterDecorations,
@@ -63,6 +64,9 @@ export function useMonacoEditor(containerRef: Ref<HTMLElement | null>, initialVa
   let refreshDebounceTimer: ReturnType<typeof setTimeout> | null = null
   const { isDark } = useTheme()
 
+  /** Monaco ships grammars only for sql/mysql/pgsql; other dialect ids use the generic sql grammar. Completion still resolves the real dialect profile per-editor. */
+  const resolveEditorLanguage = (id: SQLDialect): SQLDialect => hasGrammar(id) ? id : 'sql'
+
   const refreshGutterDecorations = () => {
     if (refreshDebounceTimer !== null)
       clearTimeout(refreshDebounceTimer)
@@ -93,7 +97,7 @@ export function useMonacoEditor(containerRef: Ref<HTMLElement | null>, initialVa
 
     editor = monaco.editor.create(containerRef.value, {
       value: initialValue.value,
-      language: options.language || 'sql',
+      language: resolveEditorLanguage(options.language || 'sql'),
       theme: isDark.value ? 'vs-dark' : 'vs',
       automaticLayout: true,
       readOnly: options.readOnly || false,
@@ -208,7 +212,7 @@ export function useMonacoEditor(containerRef: Ref<HTMLElement | null>, initialVa
     if (editor) {
       const model = editor.getModel()
       if (model) {
-        monaco.editor.setModelLanguage(model, id)
+        monaco.editor.setModelLanguage(model, resolveEditorLanguage(id))
       }
     }
   }

--- a/src/composables/useMonacoEditor.ts
+++ b/src/composables/useMonacoEditor.ts
@@ -1,9 +1,11 @@
 import type { Ref } from 'vue'
+import type { CompletionContextInput, SQLDialect } from './sqlCompletion/types'
 import type { SqlStatement, StatementToExecute } from './useSqlStatements'
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import { onBeforeUnmount } from 'vue'
-
+import { getCompletionProvider } from './sqlCompletion/provider'
 import {
   getSqlGutterDecorations,
   getStatementAtLine,
@@ -21,6 +23,7 @@ import 'monaco-editor/esm/vs/basic-languages/mysql/mysql.contribution'
 import 'monaco-editor/esm/vs/basic-languages/pgsql/pgsql.contribution'
 
 export type { ExecuteSource, StatementToExecute } from './useSqlStatements'
+export type { SQLDialect }
 
 // Configure Monaco Editor workers for Vite
 globalThis.MonacoEnvironment = {
@@ -28,8 +31,6 @@ globalThis.MonacoEnvironment = {
     return new EditorWorker()
   },
 }
-
-export type SQLDialect = 'sql' | 'mysql' | 'pgsql' | 'mssql' | 'plsql' | 'sqlite'
 
 export type MonacoEditorOptions = {
   language?: SQLDialect
@@ -40,160 +41,6 @@ export type MonacoEditorOptions = {
   showLineNumbers?: boolean
   wordWrap?: boolean
 }
-
-// SQL keywords for auto-completion
-const SQL_KEYWORDS = [
-  'SELECT',
-  'FROM',
-  'WHERE',
-  'INSERT',
-  'UPDATE',
-  'DELETE',
-  'CREATE',
-  'ALTER',
-  'DROP',
-  'TABLE',
-  'INDEX',
-  'VIEW',
-  'DATABASE',
-  'SCHEMA',
-  'JOIN',
-  'INNER',
-  'LEFT',
-  'RIGHT',
-  'OUTER',
-  'ON',
-  'AS',
-  'AND',
-  'OR',
-  'NOT',
-  'NULL',
-  'IS',
-  'IN',
-  'BETWEEN',
-  'LIKE',
-  'ORDER',
-  'BY',
-  'GROUP',
-  'HAVING',
-  'LIMIT',
-  'OFFSET',
-  'UNION',
-  'DISTINCT',
-  'COUNT',
-  'SUM',
-  'AVG',
-  'MAX',
-  'MIN',
-  'CAST',
-  'CASE',
-  'WHEN',
-  'THEN',
-  'ELSE',
-  'END',
-  'PRIMARY',
-  'KEY',
-  'FOREIGN',
-  'REFERENCES',
-  'CONSTRAINT',
-  'UNIQUE',
-  'CHECK',
-  'DEFAULT',
-  'AUTO_INCREMENT',
-  'CASCADE',
-  'SET',
-  'VALUES',
-  'INTO',
-  'BEGIN',
-  'COMMIT',
-  'ROLLBACK',
-  'TRANSACTION',
-  'SAVEPOINT',
-  'TRUNCATE',
-  'GRANT',
-  'REVOKE',
-  'WITH',
-  'RECURSIVE',
-  'WINDOW',
-  'PARTITION',
-  'OVER',
-  'ROW_NUMBER',
-  'RANK',
-  'DENSE_RANK',
-]
-
-// SQL data types
-const SQL_TYPES = [
-  'INT',
-  'INTEGER',
-  'BIGINT',
-  'SMALLINT',
-  'TINYINT',
-  'DECIMAL',
-  'NUMERIC',
-  'FLOAT',
-  'REAL',
-  'DOUBLE',
-  'CHAR',
-  'VARCHAR',
-  'TEXT',
-  'NCHAR',
-  'NVARCHAR',
-  'NTEXT',
-  'DATE',
-  'TIME',
-  'DATETIME',
-  'TIMESTAMP',
-  'YEAR',
-  'BOOLEAN',
-  'BOOL',
-  'BINARY',
-  'VARBINARY',
-  'BLOB',
-  'CLOB',
-  'JSON',
-  'UUID',
-  'SERIAL',
-  'BIGSERIAL',
-]
-
-// SQL functions
-const SQL_FUNCTIONS = [
-  'CONCAT',
-  'SUBSTRING',
-  'UPPER',
-  'LOWER',
-  'TRIM',
-  'LTRIM',
-  'RTRIM',
-  'LENGTH',
-  'REPLACE',
-  'COALESCE',
-  'NULLIF',
-  'IFNULL',
-  'NOW',
-  'CURRENT_DATE',
-  'CURRENT_TIME',
-  'CURRENT_TIMESTAMP',
-  'DATE_ADD',
-  'DATE_SUB',
-  'DATEDIFF',
-  'EXTRACT',
-  'TO_CHAR',
-  'TO_DATE',
-  'TO_NUMBER',
-  'ROUND',
-  'CEIL',
-  'FLOOR',
-  'ABS',
-  'SIGN',
-  'MOD',
-  'POWER',
-  'SQRT',
-  'EXP',
-  'LN',
-  'LOG',
-]
 
 type ExecuteGutterCallback = (lineNumber: number) => void
 type ExecuteQueryCallback = (result: StatementToExecute) => void
@@ -210,7 +57,6 @@ export type EditorCallbacks = {
 
 export function useMonacoEditor(containerRef: Ref<HTMLElement | null>, initialValue: Ref<string>, options: MonacoEditorOptions = {}) {
   let editor: monaco.editor.IStandaloneCodeEditor | null = null
-  let completionProvider: monaco.IDisposable | null = null
   let gutterDecorations: monaco.editor.IEditorDecorationsCollection | null = null
   let parsedStatements: SqlStatement[] = []
   let registeredCallbacks: EditorCallbacks | null = null
@@ -243,41 +89,7 @@ export function useMonacoEditor(containerRef: Ref<HTMLElement | null>, initialVa
     if (!containerRef.value)
       return
 
-    completionProvider = monaco.languages.registerCompletionItemProvider('sql', {
-      provideCompletionItems: (model, position) => {
-        const word = model.getWordUntilPosition(position)
-        const range = {
-          startLineNumber: position.lineNumber,
-          endLineNumber: position.lineNumber,
-          startColumn: word.startColumn,
-          endColumn: word.endColumn,
-        }
-
-        const noParenFunctions = ['NOW', 'CURRENT_DATE', 'CURRENT_TIME', 'CURRENT_TIMESTAMP']
-        const suggestions: monaco.languages.CompletionItem[] = [
-          ...SQL_KEYWORDS.map(keyword => ({
-            label: keyword,
-            kind: monaco.languages.CompletionItemKind.Keyword,
-            insertText: keyword,
-            range,
-          })),
-          ...SQL_TYPES.map(type => ({
-            label: type,
-            kind: monaco.languages.CompletionItemKind.TypeParameter,
-            insertText: type,
-            range,
-          })),
-          ...SQL_FUNCTIONS.map(func => ({
-            label: func,
-            kind: monaco.languages.CompletionItemKind.Function,
-            insertText: noParenFunctions.includes(func) ? func : `${func}()`,
-            range,
-          })),
-        ]
-
-        return { suggestions }
-      },
-    })
+    getCompletionProvider(monaco).register()
 
     editor = monaco.editor.create(containerRef.value, {
       value: initialValue.value,
@@ -392,11 +204,29 @@ export function useMonacoEditor(containerRef: Ref<HTMLElement | null>, initialVa
     monaco.editor.setTheme(dark ? 'vs-dark' : 'vs')
   }
 
+  const updateLanguage = (id: SQLDialect) => {
+    if (editor) {
+      const model = editor.getModel()
+      if (model) {
+        monaco.editor.setModelLanguage(model, id)
+      }
+    }
+  }
+
+  const setCompletionContext = (ctx: CompletionContextInput) => {
+    if (!editor)
+      return
+    getCompletionProvider(monaco).setContext(editor.getModel(), ctx)
+  }
+
   const dispose = () => {
     if (refreshDebounceTimer !== null)
       clearTimeout(refreshDebounceTimer)
     gutterDecorations?.clear()
-    completionProvider?.dispose()
+    const model = editor?.getModel()
+    if (model) {
+      getCompletionProvider(monaco).clearModel(model)
+    }
     editor?.dispose()
   }
 
@@ -410,6 +240,8 @@ export function useMonacoEditor(containerRef: Ref<HTMLElement | null>, initialVa
     setValue,
     updateTheme,
     updateOptions,
+    updateLanguage,
+    setCompletionContext,
     dispose,
     executeAtLine: (lineNumber: number) => {
       if (!editor || !registeredCallbacks)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,10 @@ import { createPinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { createApp } from 'vue'
 import App from './App.vue'
+import { setDatabaseStoreLoader } from './composables/sqlCompletion/metadata'
 import { lang } from './lang'
 import { router } from './router'
+import { useDatabaseStore } from './store/databaseStore'
 import 'virtual:uno.css'
 import './assets/index.css'
 
@@ -14,4 +16,5 @@ const app = createApp(App)
 app.use(pinia)
 app.use(router)
 app.use(lang)
+setDatabaseStoreLoader(() => useDatabaseStore)
 app.mount('#app')

--- a/src/pages/QueriesPage.vue
+++ b/src/pages/QueriesPage.vue
@@ -309,6 +309,11 @@ const completionContext = computed(() => {
   }
 })
 
+// Column prefetch covers only the currently selected schema. Schema-qualified
+// refs to other schemas (`FROM public.users` while `dbo` is selected) get no
+// column completion: the provider is synchronous (no per-keystroke backend
+// call), so a cache miss is a silent no-op. Wiring fetchTableColumns() into an
+// async resolve path is the escape hatch for multi-schema databases.
 watch(() => {
   const connId = getConnectionId()
   const db = selectedDatabase.value

--- a/src/pages/QueriesPage.vue
+++ b/src/pages/QueriesPage.vue
@@ -16,6 +16,8 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Button } from '@/components/ui/button'
 import { DestructiveConfirmDialog } from '@/components/ui/destructive-confirm-dialog'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { resolveMonacoDialect } from '@/composables/sqlCompletion/dialects'
+import { getMetadataService } from '@/composables/sqlCompletion/metadata'
 import { toast } from '@/composables/useNotifications'
 import { usePlatform } from '@/composables/usePlatform'
 import { useSqlFormatter } from '@/composables/useSqlFormatter'
@@ -108,6 +110,7 @@ watch(selectedConnectionId, (newConnId, oldConnId) => {
   tabStore.reconcileTabsForConnection(newConnId)
   if (oldConnId) {
     databaseStore.clearMetadata(oldConnId)
+    getMetadataService().clearColumnCache(oldConnId)
   }
 }, { flush: 'sync' })
 
@@ -271,6 +274,59 @@ function getActiveDialect(): string | null {
   const dbType = conn.type as DatabaseType
   return resolveDialect(dbType)
 }
+
+const activeMonacoDialect = computed(() => {
+  const formatterId = getActiveDialect()
+  return formatterId ? resolveMonacoDialect(formatterId) : 'sql'
+})
+
+const completionContext = computed(() => {
+  const connId = activeTab.value?.connectionId || getConnectionId() || undefined
+  const db = activeTab.value?.database || selectedDatabase.value || null
+  const schema = activeTab.value?.schema || selectedSchema.value || null
+  // Track async-loaded schema metadata so the provider snapshot rebuilds once
+  // databases/schemas/tables arrive (they load after connect, not at mount).
+  if (connId) {
+    const meta = databaseStore.metadata[connId]
+    if (meta) {
+      void meta.databases
+      if (db) {
+        const schemas = meta.schemas[db] ?? []
+        void schemas
+        void meta.tables[db]
+        for (const s of schemas)
+          void meta.tables[`${db}.${s}`]
+        if (schema)
+          void meta.tables[`${db}.${schema}`]
+      }
+    }
+  }
+  return {
+    connectionId: connId,
+    database: db,
+    schema,
+    dialectId: activeMonacoDialect.value,
+  }
+})
+
+watch(() => {
+  const connId = getConnectionId()
+  const db = selectedDatabase.value
+  if (!connId || !db)
+    return ''
+  const meta = databaseStore.metadata[connId]
+  if (!meta)
+    return ''
+  const key = selectedSchema.value ? `${db}.${selectedSchema.value}` : db
+  return meta.tables[key]?.map(t => t.name).join(',') ?? ''
+}, (tablesCsv) => {
+  const connId = getConnectionId()
+  const db = selectedDatabase.value
+  if (!connId || !db || !tablesCsv)
+    return
+  const tableNames = tablesCsv.split(',').filter(Boolean)
+  void getMetadataService().prefetchColumns(connId, db, selectedSchema.value || undefined, tableNames)
+})
 
 function handleFormatSql(sql?: string): string {
   const content = sql ?? activeTab.value?.content ?? ''
@@ -1225,7 +1281,8 @@ function closeResultPanel() {
                 v-if="activeTab"
                 v-model="editorContent"
                 height="100%"
-                dialect="sql"
+                :dialect="activeMonacoDialect"
+                :completion-context="completionContext"
                 :is-executing="activeTab.isExecuting"
                 :font-size="appStore.editorConfig.fontSize"
                 :tab-size="appStore.editorConfig.tabSize"


### PR DESCRIPTION
## Summary
Adds schema-aware SQL autocomplete to the Monaco editor with per-dialect profiles and metadata-driven suggestions.

## What's included
- **4-layer completion pipeline** in `src/composables/sqlCompletion/`:
  - `analyzer.ts` — parses the query at the cursor (keywords, FROM clause, table refs, aliases, CTEs)
  - `builder.ts` — builds suggestions (keywords, functions, tables, columns, schemas, databases) with prefix matching
  - `dialects.ts` — dialect profiles (postgresql, mysql, mssql, plsql, sqlite, generic sql)
  - `provider.ts` — monaco completion provider, registered for every SQL dialect id
- **Metadata service** (`metadata.ts`) — 3-level cache (connection objects / columns / derived aliases), injected store loader (browser-safe, no CommonJS `require`)
- **Wiring**: `SQLEditor.vue` + `useMonacoEditor.ts` register the provider and push dialect + completion context; `QueriesPage.vue` computes the active connection/db/schema/dialect context
- **60 unit tests** in `src/__tests__/sqlCompletion/`

## Key fixes found during manual QA
1. **First-mount wiring**: immediate watchers fired before editor instantiation → explicitly apply language + completion context in `onMounted`
2. **Browser-only crash** (`ReferenceError: Can't find variable: require`): replaced CommonJS `require('@/store/databaseStore')` with injectable `setDatabaseStoreLoader` registered in `main.ts` — jest could not catch this
3. **Snapshot staleness**: `completionContext` now tracks the full async metadata dependency graph (`meta.databases`, `meta.schemas[db]`, `meta.tables[db]` + every schema-qualified key) so the provider snapshot rebuilds after connect

## Post-review fixes (b52ad63)
1. **Syntax highlighting regression**: SQLite / SQL Server / Oracle connections render as plain text because Monaco only ships `sql`/`mysql`/`pgsql` grammars. The editor now falls back to the generic `sql` grammar when `hasGrammar(id)` is false (at both editor creation and `updateLanguage`) — completion still resolves the real dialect profile per editor.
2. **Wrong suggestions for schema-qualified words**: `public.us` with a FROM table whose columns were cached returned that table's columns instead of `public` schema tables. The analyzer no longer falls back to the last FROM table when the qualifier matches neither an alias nor a table (single-segment qualifiers only, quoted segments unquoted before compare).
3. **Provider footgun**: `getCompletionProvider` defaulted to `undefined as never`; the `monacoLike` parameter is now required.
4. **Cross-schema column completion limitation** documented at the prefetch call site and in `metadata.ts` (`FROM public.users` while another schema is active gets no column completion — sync-provider v1 tradeoff; `fetchTableColumns()` is the async escape).

## Validation
- Full suite: **519/519** jest tests pass, `vue-tsc` clean, eslint 0 errors, `npm run build` ✓
- Live-engine metadata validated against Docker Postgres 16, MySQL 8, SQL Server 2022 (list_databases/schemas/tables/columns)
- Pre-existing gap (not from this PR): Postgres/MySQL integration tests panic on missing rustls CryptoProvider in the test harness (app binary installs `aws_lc_rs::default_provider()` internally); SQL Server suite passes 6/8

## Out of scope
- `src/components/grid/DataGrid.vue` local styling change intentionally left uncommitted