### PR TITLE
docs(readme): clarify Community vs Ultimate pricing in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,12 @@ See [BUILD.md](BUILD.md) for detailed platform-specific build requirements and t
 
 <details>
 <summary><strong>Is SqlKit free?</strong></summary>
-Yes. SqlKit is open source under the Apache 2.0 license. All features are free.
+
+Yes — the **Community edition** is free and open source under the Apache 2.0 license. Connections, SQL editing, schema browsing, data editing, query history and result export are all free, with no artificial limits.
+
+Advanced capabilities — AI agent (bring your own LLM), MCP server, ER diagrams, bulk import/export and cross-engine data transfer — are part of the paid **GEEKFUN Data Studio Ultimate** subscription ($9.9/month or $99/year, with a 7-day free trial). Every version released while you're subscribed stays yours forever, even if you cancel later.
+
+[See pricing →](https://www.geekfun.club/pricing)
 </details>
 
 <details>

--- a/README_zh.md
+++ b/README_zh.md
@@ -202,7 +202,12 @@ npm run tauri dev
 
 <details>
 <summary><strong>SqlKit 是免费的吗？</strong></summary>
-是的。SqlKit 采用 Apache 2.0 许可证开源，所有功能免费使用。
+
+是的 —— **社区版**永久免费、基于 Apache 2.0 开源协议。连接、SQL 编辑、Schema 浏览、数据编辑、查询历史与结果集导出等核心功能全部免费，没有人为限制。
+
+进阶能力 —— AI 智能体（自带 LLM）、MCP 服务器、ER 图、批量导入导出与跨引擎数据传输 —— 属于付费的 **GEEKFUN Data Studio 旗舰版**订阅（$9.9/月 或 $99/年，7 天免费试用）。订阅期间发布的所有版本永久可用，取消订阅后依然归你。
+
+[了解定价详情 →](https://www.geekfun.club/zh/pricing)
 </details>
 
 <details>


### PR DESCRIPTION
## What

Updates the README FAQ (EN + ZH) to match the final GEEKFUN Data Studio pricing model — replacing the outdated "All features are free" claim.

- **Community edition** — free and open source (Apache 2.0): connections, SQL editing, schema browsing, data editing, query history, result export. No artificial limits.
- **Ultimate subscription** — $9.9/month or $99/year (7-day free trial): AI agent (bring your own LLM), MCP server, ER diagrams, bulk import/export, cross-engine data transfer.
- **Version lock** — every version released while subscribed stays usable forever, even after cancellation.

Canonical pricing policy: https://github.com/wentsen/geekfun/issues/56

## Files
- `README.md`
- `README_zh.md`